### PR TITLE
Add graphs to the environment

### DIFF
--- a/TesseractCore/Application.swift
+++ b/TesseractCore/Application.swift
@@ -6,7 +6,7 @@ public func apply(value: Value, identifier: Identifier, symbol: Symbol, paramete
 			(each.0, into.1 ?? (each.0 != into.0 ? nil : error("expected 0 or 1 edges to input \(each.0), but multiple were found \(each.0)", identifier)))
 		}.1
 	??	(parameters.last.map { $0.0 < symbol.type.arity ? nil : error("too many input edges (\($0.0 - 1))", identifier) } ?? nil)
-	??	.right(Memo(reduce(parameters, value) { into, each in into.apply(each.1.value, environment)! }))
+	??	.right(Memo(reduce(parameters, value) { into, each in into.apply(each.1.value, identifier, environment)! }))
 }
 
 

--- a/TesseractCore/Application.swift
+++ b/TesseractCore/Application.swift
@@ -6,7 +6,7 @@ public func apply(value: Value, identifier: Identifier, symbol: Symbol, paramete
 			(each.0, into.1 ?? (each.0 != into.0 ? nil : error("expected 0 or 1 edges to input \(each.0), but multiple were found \(each.0)", identifier)))
 		}.1
 	??	(parameters.last.map { $0.0 < symbol.type.arity ? nil : error("too many input edges (\($0.0 - 1))", identifier) } ?? nil)
-	??	.right(Memo(reduce(parameters, value) { into, each in into.apply(each.1.value, identifier, environment)! }))
+	??	reduce(parameters, .right(Memo(value))) { into, each in into.right?.value.apply(each.1.value, identifier, environment) ?? into }
 }
 
 

--- a/TesseractCore/Application.swift
+++ b/TesseractCore/Application.swift
@@ -6,7 +6,7 @@ public func apply(value: Value, identifier: Identifier, symbol: Symbol, paramete
 			(each.0, into.1 ?? (each.0 != into.0 ? nil : error("expected 0 or 1 edges to input \(each.0), but multiple were found \(each.0)", identifier)))
 		}.1
 	??	(parameters.last.map { $0.0 < symbol.type.arity ? nil : error("too many input edges (\($0.0 - 1))", identifier) } ?? nil)
-	??	.right(Memo(reduce(parameters, value) { into, each in into.apply(each.1.value)! }))
+	??	.right(Memo(reduce(parameters, value) { into, each in into.apply(each.1.value, environment)! }))
 }
 
 

--- a/TesseractCore/Application.swift
+++ b/TesseractCore/Application.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public func apply(value: Value, identifier: Identifier, symbol: Symbol, parameters: [(Int, Memo<Value>)]) -> Either<Error<Identifier>, Memo<Value>> {
+public func apply(value: Value, identifier: Identifier, symbol: Symbol, parameters: [(Int, Memo<Value>)], environment: Environment) -> Either<Error<Identifier>, Memo<Value>> {
 	return
 		reduce(parameters, (-1, nil as Either<Error<Identifier>, Memo<Value>>?)) { into, each in
 			(each.0, into.1 ?? (each.0 != into.0 ? nil : error("expected 0 or 1 edges to input \(each.0), but multiple were found \(each.0)", identifier)))

--- a/TesseractCore/Environment.swift
+++ b/TesseractCore/Environment.swift
@@ -27,6 +27,9 @@ public struct Environment: DictionaryLiteralConvertible, Printable {
 	}
 }
 
+
+// MARK: - Prelude
+
 public let Prelude: Environment = [
 	Symbol("unit", .Unit): Value(constant: ()),
 	Symbol("true", .Boolean): Value(constant: true),

--- a/TesseractCore/Environment.swift
+++ b/TesseractCore/Environment.swift
@@ -28,6 +28,11 @@ public struct Environment: DictionaryLiteralConvertible, Printable {
 	}
 }
 
+public func + (var left: Environment, right: (Symbol, Value)) -> Environment {
+	left[right.0] = right.1
+	return left
+}
+
 
 // MARK: - Prelude
 

--- a/TesseractCore/Environment.swift
+++ b/TesseractCore/Environment.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public struct Environment: DictionaryLiteralConvertible, Printable {
-	private let bindings: [Symbol: Value]
+	private var bindings: [Symbol: Value]
 
 	public subscript (key: String) -> (Symbol, Value)? {
 		let index = find(bindings) { symbol, _ in symbol.name == key }
@@ -9,7 +9,8 @@ public struct Environment: DictionaryLiteralConvertible, Printable {
 	}
 
 	public subscript (key: Symbol) -> Value? {
-		return bindings[key]
+		get { return bindings[key] }
+		set { bindings[key] = newValue }
 	}
 
 

--- a/TesseractCore/Evaluation.swift
+++ b/TesseractCore/Evaluation.swift
@@ -34,7 +34,6 @@ private func evaluate(graph: Graph<Node>, from: Identifier, environment: Environ
 	case .Return:
 		return inputs[0].1
 	}
-	return error("don’t know how to evaluate \(node)", from)
 }
 
 

--- a/TesseractCore/Evaluation.swift
+++ b/TesseractCore/Evaluation.swift
@@ -23,8 +23,10 @@ private func evaluate(graph: Graph<Node>, from: Identifier, environment: Environ
 			??	error("\(symbol) not found in environment", from)
 		}
 
-	case .Parameter:
-		break
+	case let .Parameter(symbol):
+		return environment[.Parameter(0, .Unit)]
+			.map { .right(Memo($0)) }
+		??	error("did not find parameter in environment", from)
 
 	case .Return where inputs.count != 1:
 		return error("expected one return edge, but \(inputs.count) were found", from)

--- a/TesseractCore/Evaluation.swift
+++ b/TesseractCore/Evaluation.swift
@@ -19,7 +19,7 @@ private func evaluate(graph: Graph<Node>, from: Identifier, environment: Environ
 	switch node {
 	case let .Symbolic(symbol):
 		return coalesce(inputs) >>- { inputs in
-				environment[symbol].map { apply($0, from, symbol, inputs) }
+				environment[symbol].map { apply($0, from, symbol, inputs, environment) }
 			??	error("\(symbol) not found in environment", from)
 		}
 

--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -83,6 +83,13 @@ public struct Graph<T> {
 }
 
 
+public func == <T: Equatable> (left: Graph<T>, right: Graph<T>) -> Bool {
+	return
+		left.nodes == right.nodes
+	&&	left.edges == right.edges
+}
+
+
 // MARK: - Imports
 
 import Prelude

--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -20,6 +20,10 @@ public struct Graph<T> {
 		}
 	}
 
+	public subscript (position: DictionaryIndex<Identifier, T>) -> (Identifier, T) {
+		return nodes[position]
+	}
+
 	public var edges: Set<Edge> {
 		didSet {
 			sanitize(edges - oldValue)

--- a/TesseractCore/Node.swift
+++ b/TesseractCore/Node.swift
@@ -23,6 +23,16 @@ public enum Node: Equatable, Printable {
 	}
 
 
+	public var isReturn: Bool {
+		switch self {
+		case Return:
+			return true
+		default:
+			return false
+		}
+	}
+
+
 	public var description: String {
 		switch self {
 		case let Parameter(symbol):

--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -43,9 +43,9 @@ public enum Value: Printable {
 	public var description: String {
 		switch self {
 		case let Constant(c):
-			return ".Constant(\(toString(c)))"
+			return ".Constant(\(c))"
 		case let Function(f):
-			return ".Function(\(toString(f)))"
+			return ".Function(\(f))"
 		}
 	}
 }

--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -46,9 +46,14 @@ public enum Value: Printable {
 
 
 	public func apply(argument: Value) -> Value? {
-		return (function() as (Any -> Any)?)
-			.map { argument.constant().map($0) }?
-			.map { Value(constant: $0) }
+		switch self {
+		case let Function(function) where function.value is Any -> Any:
+			return argument.constant()
+				.map(function.value as Any -> Any)
+				.map { Value(constant: $0) }
+		default:
+			return nil
+		}
 	}
 
 

--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -52,6 +52,11 @@ public enum Value: Printable {
 				.map(function.value as Any -> Any)
 				.map { applied in .right(Memo(Value(constant: applied))) }
 			??	error("could not apply function", identifier)
+		case let Graph(graph):
+			return graph
+				.find { $1.isReturn }
+				.map { evaluate(graph, graph[$0].0, environment) }
+			??	error("could not find return node", identifier)
 		default:
 			return error("cannot apply \(self)", identifier)
 		}

--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -45,14 +45,15 @@ public enum Value: Printable {
 	}
 
 
-	public func apply(argument: Value, _ identifier: Identifier, _ environment: Environment) -> Value? {
+	public func apply(argument: Value, _ identifier: Identifier, _ environment: Environment) -> Either<Error<Identifier>, Memo<Value>> {
 		switch self {
 		case let Function(function) where function.value is Any -> Any:
 			return argument.constant()
 				.map(function.value as Any -> Any)
-				.map { Value(constant: $0) }
+				.map { applied in .right(Memo(Value(constant: applied))) }
+			??	error("could not apply function", identifier)
 		default:
-			return nil
+			return error("cannot apply \(self)", identifier)
 		}
 	}
 
@@ -75,3 +76,5 @@ public enum Value: Printable {
 // MARK: - Imports
 
 import Box
+import Either
+import Memo

--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -45,7 +45,7 @@ public enum Value: Printable {
 	}
 
 
-	public func apply(argument: Value, _ environment: Environment) -> Value? {
+	public func apply(argument: Value, _ identifier: Identifier, _ environment: Environment) -> Value? {
 		switch self {
 		case let Function(function) where function.value is Any -> Any:
 			return argument.constant()

--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -35,6 +35,15 @@ public enum Value: Printable {
 		}
 	}
 
+	public var graph: TesseractCore.Graph<Node>? {
+		switch self {
+		case let Graph(graph):
+			return graph
+		default:
+			return nil
+		}
+	}
+
 
 	public func apply(argument: Value) -> Value? {
 		return (function() as (Any -> Any)?)

--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -55,7 +55,7 @@ public enum Value: Printable {
 		case let Graph(graph):
 			return graph
 				.find { $1.isReturn }
-				.map { evaluate(graph, graph[$0].0, environment) }
+				.map { evaluate(graph, graph[$0].0, environment + (.Parameter(0, .Unit), argument)) }
 			??	error("could not find return node", identifier)
 		default:
 			return error("cannot apply \(self)", identifier)

--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -11,6 +11,7 @@ public enum Value: Printable {
 
 	case Constant(Box<Any>)
 	case Function(Box<Any>)
+	case Graph(TesseractCore.Graph<Node>)
 
 	public func constant<T>() -> T? {
 		switch self {
@@ -46,6 +47,8 @@ public enum Value: Printable {
 			return ".Constant(\(constant))"
 		case let Function(function):
 			return ".Function(\(function))"
+		case let Graph(graph):
+			return ".Graph(\(graph))"
 		}
 	}
 }

--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -42,10 +42,10 @@ public enum Value: Printable {
 
 	public var description: String {
 		switch self {
-		case let Constant(c):
-			return ".Constant(\(c))"
-		case let Function(f):
-			return ".Function(\(f))"
+		case let Constant(constant):
+			return ".Constant(\(constant))"
+		case let Function(function):
+			return ".Function(\(function))"
 		}
 	}
 }

--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -45,7 +45,7 @@ public enum Value: Printable {
 	}
 
 
-	public func apply(argument: Value) -> Value? {
+	public func apply(argument: Value, _ environment: Environment) -> Value? {
 		switch self {
 		case let Function(function) where function.value is Any -> Any:
 			return argument.constant()

--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -9,6 +9,10 @@ public enum Value: Printable {
 		self = Function(Box(function))
 	}
 
+	public init(graph: TesseractCore.Graph<Node>) {
+		self = Graph(graph)
+	}
+
 	case Constant(Box<Any>)
 	case Function(Box<Any>)
 	case Graph(TesseractCore.Graph<Node>)

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -57,6 +57,6 @@ final class EvaluationTests: XCTestCase {
 		let (c, d) = (Identifier(), Identifier())
 		let graph = Graph(nodes: [ c: node("true"), d: .Symbolic(identitySymbol) ], edges: [ Edge((c, 0), (d, 0)) ])
 		let evaluated = evaluate(graph, d, Prelude + (identitySymbol, Value(graph: identity)))
-		assertRight(evaluated)?.value
+		assertEqual(assertNotNil(assertRight(evaluated)?.value.constant()), true)
 	}
 }

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -57,6 +57,6 @@ final class EvaluationTests: XCTestCase {
 		let (c, d) = (Identifier(), Identifier())
 		let graph = Graph(nodes: [ c: node("true"), d: .Symbolic(identitySymbol) ], edges: [ Edge((c, 0), (d, 0)) ])
 		let evaluated = evaluate(graph, d, Prelude + (identitySymbol, Value(graph: identity)))
-		println(assertRight(evaluated)?.value)
+		assertRight(evaluated)?.value
 	}
 }

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -4,9 +4,17 @@ import TesseractCore
 import XCTest
 
 final class EvaluationTests: XCTestCase {
-	func testConstantNodeEvaluatesToConstant() {
+	func createGraph(symbol: Symbol) -> (Identifier, Graph<Node>) {
 		let a = Identifier()
-		let graph = Graph(nodes: [ a: Node.Symbolic(Prelude["true"]!.0) ])
+		return (a, Graph(nodes: [ a: Node.Symbolic(symbol) ]))
+	}
+
+	var constantGraph: (Identifier, Graph<Node>) {
+		return createGraph(Prelude["true"]!.0)
+	}
+
+	func testConstantNodeEvaluatesToConstant() {
+		let (a, graph) = constantGraph
 		let evaluated = evaluate(graph, a)
 
 		assertEqual(assertNotNil(assertRight(evaluated)?.value.constant()), true)

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -9,6 +9,10 @@ final class EvaluationTests: XCTestCase {
 		return (a, Graph(nodes: [ a: .Symbolic(symbol) ]))
 	}
 
+	func node(symbolName: String) -> Node {
+		return .Symbolic(Prelude[symbolName]!.0)
+	}
+
 	var constantGraph: (Identifier, Graph<Node>) {
 		return createGraph(Prelude["true"]!.0)
 	}

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -21,8 +21,7 @@ final class EvaluationTests: XCTestCase {
 	}
 
 	func testFunctionNodeWithNoBoundInputsEvaluatesToFunction() {
-		let a = Identifier()
-		let graph = Graph(nodes: [ a: Node.Symbolic(Prelude["identity"]!.0) ])
+		let (a, graph) = createGraph(Prelude["identity"]!.0)
 		let evaluated = evaluate(graph, a)
 
 		assertEqual(assertNotNil(assertRight(evaluated)?.value.function() as (Any -> Any)?).map { $0(1) as Int }, 1)
@@ -34,5 +33,10 @@ final class EvaluationTests: XCTestCase {
 		let evaluated = evaluate(graph, b)
 
 		assertEqual(assertNotNil(assertRight(evaluated)?.value.constant()), true)
+	}
+
+	func testGraphNodeWithNoBoundInputsEvaluatesToGraph() {
+		let (a, graph) = constantGraph
+		//
 	}
 }

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -48,4 +48,15 @@ final class EvaluationTests: XCTestCase {
 		let evaluated = evaluate(graph, c, [truthy: Value(graph: constant)])
 		assertEqual(assertRight(evaluated)?.value.graph.map { $0 == constant } ?? false, true)
 	}
+
+	func testGraphNodeWithBoundInputsAppliesInput() {
+		let (a, b) = (Identifier(), Identifier())
+		let identity = Graph<Node>(nodes: [ a: .Parameter(.Parameter(0, .Parameter(0))), b: .Return(.Named("return", .Parameter(0))) ], edges: [ Edge((a, 0), (b, 0)) ])
+
+		let identitySymbol = Symbol.Named("identity", Type(function: 0, 0))
+		let (c, d) = (Identifier(), Identifier())
+		let graph = Graph(nodes: [ c: node("true"), d: .Symbolic(identitySymbol) ], edges: [ Edge((c, 0), (d, 0)) ])
+		let evaluated = evaluate(graph, d, Prelude + (identitySymbol, Value(graph: identity)))
+		println(assertRight(evaluated)?.value)
+	}
 }

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class EvaluationTests: XCTestCase {
 	func createGraph(symbol: Symbol) -> (Identifier, Graph<Node>) {
 		let a = Identifier()
-		return (a, Graph(nodes: [ a: Node.Symbolic(symbol) ]))
+		return (a, Graph(nodes: [ a: .Symbolic(symbol) ]))
 	}
 
 	var constantGraph: (Identifier, Graph<Node>) {

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -36,7 +36,12 @@ final class EvaluationTests: XCTestCase {
 	}
 
 	func testGraphNodeWithNoBoundInputsEvaluatesToGraph() {
-		let (a, graph) = constantGraph
-		//
+		let (a, b) = (Identifier(), Identifier())
+		let constant = Graph<Node>(nodes: [ a: .Symbolic(Prelude["true"]!.0), b: .Return(.Named("return", .Boolean)) ], edges: [ Edge((a, 0), (b, 0)) ])
+
+		let truthy = Symbol.Named("truthy", .Boolean)
+		let (c, graph) = createGraph(truthy)
+		let evaluated = evaluate(graph, c, [truthy: Value(graph: constant)])
+		assertEqual(assertRight(evaluated)?.value.graph.map { $0 == constant } ?? false, true)
 	}
 }

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -33,7 +33,7 @@ final class EvaluationTests: XCTestCase {
 
 	func testFunctionNodeWithBoundInputAppliesInput() {
 		let (a, b) = (Identifier(), Identifier())
-		let graph = Graph(nodes: [ a: Node.Symbolic(Prelude["true"]!.0), b: Node.Symbolic(Prelude["identity"]!.0) ], edges: [ Edge((a, 0), (b, 0)) ])
+		let graph = Graph(nodes: [ a: node("true"), b: node("identity") ], edges: [ Edge((a, 0), (b, 0)) ])
 		let evaluated = evaluate(graph, b)
 
 		assertEqual(assertNotNil(assertRight(evaluated)?.value.constant()), true)
@@ -41,7 +41,7 @@ final class EvaluationTests: XCTestCase {
 
 	func testGraphNodeWithNoBoundInputsEvaluatesToGraph() {
 		let (a, b) = (Identifier(), Identifier())
-		let constant = Graph<Node>(nodes: [ a: .Symbolic(Prelude["true"]!.0), b: .Return(.Named("return", .Boolean)) ], edges: [ Edge((a, 0), (b, 0)) ])
+		let constant = Graph<Node>(nodes: [ a: node("true"), b: .Return(.Named("return", .Boolean)) ], edges: [ Edge((a, 0), (b, 0)) ])
 
 		let truthy = Symbol.Named("truthy", .Boolean)
 		let (c, graph) = createGraph(truthy)

--- a/TesseractCoreTests/ValueTests.swift
+++ b/TesseractCoreTests/ValueTests.swift
@@ -31,14 +31,14 @@ final class ValueTests: XCTestCase {
 	}
 
 
-	func testApplicationOfConstantIsNil() {
+	func testApplicationOfConstantIsError() {
 		let value = Value(constant: ())
-		assertNil(value.apply(value))
+		assertLeft(value.apply(value, Identifier(), [:]))
 	}
 
 	func testApplicationOfIdentityIsArgument() {
 		let argument = Value(constant: 1)
 		let identity = Value(function: id as Any -> Any)
-		assertEqual(assertNotNil(identity.apply(argument))?.constant(), 1)
+		assertEqual(assertNotNil(identity.apply(argument, Identifier(), [:]).right)?.value.constant(), 1)
 	}
 }


### PR DESCRIPTION
Extends `Value` to include `Graph`s, and extends `apply()` and `Value.apply()` to handle `Graph`s.

Fixes #28.

- [x] Evaluate `Parameter` nodes.
- [x] Append parameters to the environment when applying `Graph` values.
- ~~Use the correct index and type for the `Parameter` symbol when applying `Graph` values.~~ It’s not clear that the former is important at all right now, and the latter won’t be important until we do typechecking.