### PR TITLE
Tidy exporting

### DIFF
--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -1,12 +1,12 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public func export<T>(graph: Graph<T>) -> String {
-    var result = "digraph tesseract {\n"
-	result += reduce(graph.edges, "") {
-		$0 + "\t" + $1.source.identifier.description + " -> " + $1.destination.identifier.description + ";\n"
-	}
-    result += "}"
-    return result
+	return
+		"digraph tesseract {\n"
+	+	reduce(graph.edges, "") {
+			$0 + "\t" + $1.source.identifier.description + " -> " + $1.destination.identifier.description + ";\n"
+		}
+	+	"}"
 }
 
 

--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -1,12 +1,8 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-private func concat(strings: [String]) -> String {
-    return reduce(strings, "", +)
-}
-
 public func export<T>(graph: Graph<T>) -> String {
     var result = "digraph tesseract {\n"
-    result += concat(map(graph.edges, { edge in "\t" + edge.source.identifier.description + " -> " + edge.destination.identifier.description + ";\n" }))
+    result += reduce(map(graph.edges, { edge in "\t" + edge.source.identifier.description + " -> " + edge.destination.identifier.description + ";\n" }), "", +)
     result += "}"
     return result
 }

--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -2,7 +2,9 @@
 
 public func export<T>(graph: Graph<T>) -> String {
     var result = "digraph tesseract {\n"
-    result += reduce(map(graph.edges, { edge in "\t" + edge.source.identifier.description + " -> " + edge.destination.identifier.description + ";\n" }), "", +)
+	result += reduce(graph.edges, "") {
+		$0 + "\t" + $1.source.identifier.description + " -> " + $1.destination.identifier.description + ";\n"
+	}
     result += "}"
     return result
 }

--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -15,4 +15,3 @@ public func export<T>(graph: Graph<T>) -> String {
 // MARK: - Imports
 
 import Prelude
-import Foundation

--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -1,10 +1,8 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public func export<T>(graph: Graph<T>) -> String {
-	return
-		"digraph tesseract {\n"
-	+	join("", lazy(graph.edges).map { "\t" + $0.source.identifier.description + " -> " + $0.destination.identifier.description + ";\n" })
-	+	"}"
+	let edges = join("\n", lazy(graph.edges).map { "\t" + $0.source.identifier.description + " -> " + $0.destination.identifier.description + ";" })
+	return "digraph tesseract {\n\(edges)\n}"
 }
 
 

--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -11,6 +11,8 @@ public func export<T>(graph: Graph<T>) -> String {
     return result
 }
 
+
 // MARK: - Imports
+
 import Prelude
 import Foundation

--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -3,9 +3,7 @@
 public func export<T>(graph: Graph<T>) -> String {
 	return
 		"digraph tesseract {\n"
-	+	reduce(graph.edges, "") {
-			$0 + "\t" + $1.source.identifier.description + " -> " + $1.destination.identifier.description + ";\n"
-		}
+	+	join("", lazy(graph.edges).map { "\t" + $0.source.identifier.description + " -> " + $0.destination.identifier.description + ";\n" })
 	+	"}"
 }
 

--- a/TesseractCoreTests/ExportingTests.swift
+++ b/TesseractCoreTests/ExportingTests.swift
@@ -1,6 +1,5 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-import Prelude
 import TesseractCore
 import XCTest
 

--- a/TesseractCoreTests/ExportingTests.swift
+++ b/TesseractCoreTests/ExportingTests.swift
@@ -1,8 +1,5 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-import TesseractCore
-import XCTest
-
 final class ExportingTests: XCTestCase {
     func testExporting() {
         let (a, b) = (Identifier(), Identifier())
@@ -10,3 +7,9 @@ final class ExportingTests: XCTestCase {
         XCTAssertEqual(export(graph), "digraph tesseract {\n\t\(a) -> \(b);\n}")
     }
 }
+
+
+// MARK: - Imports
+
+import TesseractCore
+import XCTest


### PR DESCRIPTION
Tidies @amackworth’s excellent `Graph` exporting from #34 a little bit:

- tabs
- blank lines consistent with the rest
- `join` a `lazy` `map`
- interpolation
- no mutation