### PR TITLE
[WIP] Import and export identifiers

### DIFF
--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -1,19 +1,28 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public func exportDOT<T>(name: String, graph: Graph<T>) -> String {
-	let edges = join("\n", lazy(graph.edges).map(serializeEdge <| graph))
-	return "digraph \(name) {\n\(edges)\n}"
+	// NB: this would be lazy(graph).map(…) but for a compiler crash in Swift 1.2b1
+	let nodes = join("\n", map(graph) { join("\n", serialize($0).map { "\t\($0);" }) })
+	return "digraph \(name) {\n\(nodes)\n}"
 }
 
+private func serialize(identifier: Identifier) -> String {
+	return "\"\(identifier)\""
+}
 
-private func serializeEdge<T>(graph: Graph<T>, edge: Edge) -> String {
-	let node = serializeNode <| graph
-	return "\t\(node(edge.source.identifier)) -> \(node(edge.destination.identifier))\(serializeAttributes(attributes(edge)));"
+private func serialize<T>(node: NodeView<T>) -> [String] {
+	let attributes = ["label": "\(node.value)"]
+	let edges = join([], lazy(node.outEdges).map { join([], map($1, serialize)) })
+	return ["\(serialize(node.identifier))\(serialize(attributes))"] + edges
+}
+
+private func serialize<T>(edge: EdgeView<T>) -> [String] {
+	return ["\(serialize(edge.edge.source.identifier)) -> \(serialize(edge.edge.destination.identifier))\(serialize(attributes(edge.edge)))"]
 }
 
 private typealias Attributes = [String: String]
 
-private func serializeAttributes(attributes: Attributes) -> String {
+private func serialize(attributes: Attributes) -> String {
 	let serialized = join(",", lazy(attributes).map { "\($0)=\($1)" })
 	return attributes.count > 0 ? " [\(serialized)]" : ""
 }
@@ -24,12 +33,7 @@ private func attributes(edge: Edge) -> Attributes {
 		"sametail": toString(edge.source.outputIndex),
 		"headlabel": toString(edge.destination.inputIndex),
 		"samehead": toString(edge.destination.inputIndex),
-		"labeldistance": "2",
 	]
-}
-
-private func serializeNode<T>(graph: Graph<T>, identifier: Identifier) -> String {
-	return "\"\(graph.nodes[identifier]!)\""
 }
 
 

--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -8,7 +8,24 @@ public func exportDOT<T>(graph: Graph<T>) -> String {
 
 private func serializeEdge<T>(graph: Graph<T>, edge: Edge) -> String {
 	let node = serializeNode <| graph
-	return "\t\(node(edge.source.identifier)) -> \(node(edge.destination.identifier));"
+	return "\t\(node(edge.source.identifier)) -> \(node(edge.destination.identifier))\(serializeAttributes(attributes(edge)));"
+}
+
+private typealias Attributes = [String: String]
+
+private func serializeAttributes(attributes: Attributes) -> String {
+	let serialized = join(",", lazy(attributes).map { "\($0)=\($1)" })
+	return attributes.count > 0 ? " [\(serialized)]" : ""
+}
+
+private func attributes(edge: Edge) -> Attributes {
+	return [
+		"taillabel": toString(edge.source.outputIndex),
+		"sametail": toString(edge.source.outputIndex),
+		"headlabel": toString(edge.destination.inputIndex),
+		"samehead": toString(edge.destination.inputIndex),
+		"labeldistance": "2",
+	]
 }
 
 private func serializeNode<T>(graph: Graph<T>, identifier: Identifier) -> String {

--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -1,10 +1,13 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public func exportDOT<T>(graph: Graph<T>) -> String {
-	let edges = join("\n", lazy(graph.edges).map { edge in
-		"\t\"\(graph.nodes[edge.source.identifier]!)\" -> \"\(graph.nodes[edge.destination.identifier]!)\";"
-	})
+	let edges = join("\n", lazy(graph.edges).map(serializeEdge <| graph))
 	return "digraph tesseract {\n\(edges)\n}"
+}
+
+
+private func serializeEdge<T>(graph: Graph<T>, edge: Edge) -> String {
+	return "\t\"\(graph.nodes[edge.source.identifier]!)\" -> \"\(graph.nodes[edge.destination.identifier]!)\";"
 }
 
 

--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -1,13 +1,8 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
+
 public func exportDOT<T>(graph: Graph<T>) -> String {
 	let edges = join("\n", lazy(graph.edges).map { edge in
-		let sourceID = edge.source.identifier
-		let destinationID = edge.destination.identifier
-		let source = graph.nodes[sourceID]
-		let destination = graph.nodes[destinationID]
-		let sourceDescription = source.map(toString) ?? ""
-		let destinationDescription = destination.map(toString) ?? ""
-		return "\t\"" + sourceDescription + "\" -> \"" + destinationDescription + "\";"
+		"\t\"\(graph.nodes[edge.source.identifier]!)\" -> \"\(graph.nodes[edge.destination.identifier]!)\";"
 	})
 	return "digraph tesseract {\n\(edges)\n}"
 }

--- a/TesseractCore/Exporting.swift
+++ b/TesseractCore/Exporting.swift
@@ -7,7 +7,12 @@ public func exportDOT<T>(graph: Graph<T>) -> String {
 
 
 private func serializeEdge<T>(graph: Graph<T>, edge: Edge) -> String {
-	return "\t\"\(graph.nodes[edge.source.identifier]!)\" -> \"\(graph.nodes[edge.destination.identifier]!)\";"
+	let node = serializeNode <| graph
+	return "\t\(node(edge.source.identifier)) -> \(node(edge.destination.identifier));"
+}
+
+private func serializeNode<T>(graph: Graph<T>, identifier: Identifier) -> String {
+	return "\"\(graph.nodes[identifier]!)\""
 }
 
 

--- a/TesseractCore/Identifier.swift
+++ b/TesseractCore/Identifier.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2014 Rob Rix. All rights reserved.
 
-public struct Identifier: Comparable, Hashable, Printable {
+public struct Identifier: Comparable, Hashable, IntegerLiteralConvertible, Printable {
 	public init() {
 		self.value = Identifier.cursor++
 	}
@@ -21,6 +21,13 @@ public struct Identifier: Comparable, Hashable, Printable {
 
 	public var hashValue: Int {
 		return value.hashValue
+	}
+
+
+	// MARK: IntegerLiteralConvertible
+
+	public init(integerLiteral value: IntegerLiteralType) {
+		self.value = value
 	}
 
 

--- a/TesseractCoreTests/ExportingTests.swift
+++ b/TesseractCoreTests/ExportingTests.swift
@@ -4,7 +4,7 @@ final class ExportingTests: XCTestCase {
 	func testExporting() {
 		let (a, b) = (Identifier(), Identifier())
 		let graph = Graph(nodes: [ a: "item1", b: "item2" ], edges: [ Edge((a, 0), (b, 0)) ])
-		XCTAssertEqual(exportDOT(graph), "digraph tesseract {\n\t\"item1\" -> \"item2\";\n}")
+		XCTAssertEqual(exportDOT(graph), "digraph tesseract {\n\t\"item1\" -> \"item2\" [sametail=0,headlabel=0,samehead=0,labeldistance=2,taillabel=0];\n}")
 	}
 }
 


### PR DESCRIPTION
- [ ] Parse DOT into `(name: String, graph: Graph<(identifier: String, attributes: [String: String])>)`.
- [ ] Parse `Identifier`s.
- [ ] Test parsing under `Graph<T>` equality.

Fixes #41.
Fixes #44.