### PR TITLE
Graph type inference

### DIFF
--- a/TesseractCore.xcodeproj/project.pbxproj
+++ b/TesseractCore.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		D4F48AC81AAE918C0017504F /* GraphDifferentiator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F48AC71AAE918C0017504F /* GraphDifferentiator.swift */; };
 		D4F48ACA1AAE91BF0017504F /* ForwardDifferential.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F48AC91AAE91BF0017504F /* ForwardDifferential.swift */; };
 		D4F5A8CE1A520E7F0058EFDC /* Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F5A8CD1A520E7F0058EFDC /* Identifier.swift */; };
+		D4FF06B31AC10612004DB780 /* Inference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FF06B21AC10612004DB780 /* Inference.swift */; };
+		D4FF06B51AC10735004DB780 /* InferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FF06B41AC10735004DB780 /* InferenceTests.swift */; };
 		D4FF06B71AC10900004DB780 /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FF06B61AC10900004DB780 /* NodeTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -113,6 +115,8 @@
 		D4F48AC71AAE918C0017504F /* GraphDifferentiator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphDifferentiator.swift; sourceTree = "<group>"; };
 		D4F48AC91AAE91BF0017504F /* ForwardDifferential.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForwardDifferential.swift; sourceTree = "<group>"; };
 		D4F5A8CD1A520E7F0058EFDC /* Identifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Identifier.swift; sourceTree = "<group>"; };
+		D4FF06B21AC10612004DB780 /* Inference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Inference.swift; sourceTree = "<group>"; };
+		D4FF06B41AC10735004DB780 /* InferenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InferenceTests.swift; sourceTree = "<group>"; };
 		D4FF06B61AC10900004DB780 /* NodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -184,6 +188,7 @@
 				D47974041A7D92E00034ABA2 /* Evaluation.swift */,
 				11C1526A1A830A160044FCA2 /* Exporting.swift */,
 				11C9E2481A83C17F0023AB0D /* Importing.swift */,
+				D4FF06B21AC10612004DB780 /* Inference.swift */,
 				D47974061A7D99A40034ABA2 /* Application.swift */,
 				D479740B1A7DA6DC0034ABA2 /* Error.swift */,
 				D42F30E81A8DAD3500F3EA38 /* NodeView.swift */,
@@ -219,6 +224,7 @@
 				D41275841A78638900CC910A /* EvaluationTests.swift */,
 				D47974021A7D277C0034ABA2 /* ValueTests.swift */,
 				D4FF06B61AC10900004DB780 /* NodeTests.swift */,
+				D4FF06B41AC10735004DB780 /* InferenceTests.swift */,
 				1182B03A1A84381B002E7D2D /* ImportingTests.swift */,
 				11C1526C1A830FFA0044FCA2 /* ExportingTests.swift */,
 				D479740D1A7DEE9E0034ABA2 /* ErrorTests.swift */,
@@ -366,6 +372,7 @@
 				D4F48AC41AAE90D70017504F /* SetDifferentiator.swift in Sources */,
 				D4CB5DBF1A75E12D00672C6B /* Edge.swift in Sources */,
 				D4F48AC61AAE91380017504F /* DictionaryDifferentiator.swift in Sources */,
+				D4FF06B31AC10612004DB780 /* Inference.swift in Sources */,
 				D4F48ACA1AAE91BF0017504F /* ForwardDifferential.swift in Sources */,
 				11C9E2491A83C17F0023AB0D /* Importing.swift in Sources */,
 				D4CB5DC31A75E53D00672C6B /* Node.swift in Sources */,
@@ -388,6 +395,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4C893BD1A51DCC10078743E /* GraphTests.swift in Sources */,
+				D4FF06B51AC10735004DB780 /* InferenceTests.swift in Sources */,
 				1182B03B1A84381B002E7D2D /* ImportingTests.swift in Sources */,
 				D4B5220F1A9D952500F33502 /* Fixtures.swift in Sources */,
 				D4FF06B71AC10900004DB780 /* NodeTests.swift in Sources */,

--- a/TesseractCore.xcodeproj/project.pbxproj
+++ b/TesseractCore.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		D4F48AC81AAE918C0017504F /* GraphDifferentiator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F48AC71AAE918C0017504F /* GraphDifferentiator.swift */; };
 		D4F48ACA1AAE91BF0017504F /* ForwardDifferential.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F48AC91AAE91BF0017504F /* ForwardDifferential.swift */; };
 		D4F5A8CE1A520E7F0058EFDC /* Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F5A8CD1A520E7F0058EFDC /* Identifier.swift */; };
+		D4FF06B71AC10900004DB780 /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FF06B61AC10900004DB780 /* NodeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -112,6 +113,7 @@
 		D4F48AC71AAE918C0017504F /* GraphDifferentiator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphDifferentiator.swift; sourceTree = "<group>"; };
 		D4F48AC91AAE91BF0017504F /* ForwardDifferential.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForwardDifferential.swift; sourceTree = "<group>"; };
 		D4F5A8CD1A520E7F0058EFDC /* Identifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Identifier.swift; sourceTree = "<group>"; };
+		D4FF06B61AC10900004DB780 /* NodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -216,6 +218,7 @@
 				D4C893BC1A51DCC10078743E /* GraphTests.swift */,
 				D41275841A78638900CC910A /* EvaluationTests.swift */,
 				D47974021A7D277C0034ABA2 /* ValueTests.swift */,
+				D4FF06B61AC10900004DB780 /* NodeTests.swift */,
 				1182B03A1A84381B002E7D2D /* ImportingTests.swift */,
 				11C1526C1A830FFA0044FCA2 /* ExportingTests.swift */,
 				D479740D1A7DEE9E0034ABA2 /* ErrorTests.swift */,
@@ -387,6 +390,7 @@
 				D4C893BD1A51DCC10078743E /* GraphTests.swift in Sources */,
 				1182B03B1A84381B002E7D2D /* ImportingTests.swift in Sources */,
 				D4B5220F1A9D952500F33502 /* Fixtures.swift in Sources */,
+				D4FF06B71AC10900004DB780 /* NodeTests.swift in Sources */,
 				11C1526D1A830FFA0044FCA2 /* ExportingTests.swift in Sources */,
 				D41275851A78638900CC910A /* EvaluationTests.swift in Sources */,
 				D479740E1A7DEE9E0034ABA2 /* ErrorTests.swift in Sources */,

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -25,20 +25,5 @@ private func typeOf(graph: Graph<Node>, endpoint: (identifier: Identifier, input
 }
 
 
-private func simplify(type: Term) -> Term {
-	return Substitution(
-		(type.freeVariables
-			|>	sorted
-			|>	reverse
-			|>	enumerate
-			|>	lazy)
-			.map {
-				($1, Term(integerLiteral: $0))
-			})
-		.apply(type)
-		.generalize()
-}
-
-
 import Manifold
 import Prelude

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -1,12 +1,12 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet) {
-	let parameters = Node.parameters(graph)
-	let returns = Node.returns(graph)
-	let returnType: Term = reduce(returns, nil) { $0.0.map { .product(Term(), $0) } ?? Term() } ?? .Unit
-	return (simplify(reduce(parameters, returnType) {
-		.function(Term(), $0.0)
-	}), [])
+	let types = graph.map { $0.symbol.type }
+
+	let returns = Node.returns(graph).map { typeOf(graph, $0.0)! }
+	let parameters = Node.parameters(graph).map { typeOf(graph, $0.0)! }
+	let returnType: Term? = reduce(returns, nil) { previous, each in previous.map { Term.product(each, $0) } ?? each }
+	return (simplify(reduce(parameters, returnType ?? .Unit, flip(Term.function))), [])
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -1,6 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public func constraints(graph: Graph<Node>) -> (Term, assumptions: AssumptionSet, constraints: ConstraintSet) {
+	let parameters = Node.parameters(graph)
 	let returns = Node.returns(graph)
 	if returns.count == 0 {
 		return (.Unit, [:], [])

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -14,6 +14,7 @@ private func typeOf(graph: Graph<Node>, identifier: Identifier) -> Term? {
 	return graph.nodes[identifier]?.type
 }
 
+/// Returns the type of the node input at `endpoint` in `graph`. For `return` nodes (which have no parameters), this will be the node’s type.
 private func typeOf(graph: Graph<Node>, endpoint: (identifier: Identifier, inputIndex: Int)) -> Term? {
 	return graph.nodes[endpoint.identifier].map {
 		$0.`return` != nil ?

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -13,7 +13,7 @@ public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet
 private func simplify(type: Term) -> Term {
 	return Substitution(
 		(type.freeVariables
-			|>	(flip(sorted) <| { $0.value < $1.value })
+			|>	sorted
 			|>	reverse
 			|>	enumerate
 			|>	lazy)

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -14,6 +14,10 @@ private func typeOf(graph: Graph<Node>, identifier: Identifier) -> Term? {
 	return graph.nodes[identifier]?.type
 }
 
+private func typeOf(graph: Graph<Node>, endpoint: (identifier: Identifier, inputIndex: Int)) -> Term? {
+	return graph.nodes[endpoint.identifier]?.symbol.type.parameters[endpoint.inputIndex]
+}
+
 
 private func simplify(type: Term) -> Term {
 	return Substitution(

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -3,7 +3,7 @@
 public func constraints(graph: Graph<Node>) -> (Term, assumptions: AssumptionSet, constraints: ConstraintSet) {
 	let parameters = Node.parameters(graph)
 	let returns = Node.returns(graph)
-	return (reduce(parameters, Term.Unit) {
+	return (reduce(parameters, returns.count > 0 ? Term() : Term.Unit) {
 		.function(Term(), $0.0)
 	}, [:], [])
 }

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -1,5 +1,13 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
+public func typeOf(graph: Graph<Node>) -> Either<Error<Identifier>, Term> {
+	let (type, constraints) = TesseractCore.constraints(graph)
+	return solve(constraints).either(
+		ifLeft: { Either.left(Error($0.description, Identifier())) },
+		ifRight: { Either.right($0.apply(type)) })
+}
+
+
 public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet) {
 	let parameters = Node.parameters(graph).map { typeOf(graph, $0.0)! }.reverse()
 	let returns = Node.returns(graph).map { typeOf(graph, $0.0)! }.reverse()
@@ -25,5 +33,6 @@ private func typeOf(graph: Graph<Node>, endpoint: (identifier: Identifier, input
 }
 
 
+import Either
 import Manifold
 import Prelude

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -4,10 +4,16 @@ public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet
 	let parameters = Node.parameters(graph)
 	let returns = Node.returns(graph)
 	let returnType: Term = reduce(returns, nil) { $0.0.map { .product(Term(), $0) } ?? Term() } ?? .Unit
-	return (reduce(parameters, returnType) {
+	return (simplify(reduce(parameters, returnType) {
 		.function(Term(), $0.0)
-	}, [])
+	}), [])
+}
+
+
+private func simplify(type: Term) -> Term {
+	return Substitution(lazy(enumerate(type.freeVariables |> (flip(sorted) <| { $0.value < $1.value }))).map { ($1, Term(integerLiteral: $0)) }).apply(type)
 }
 
 
 import Manifold
+import Prelude

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -10,6 +10,11 @@ public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet
 }
 
 
+private func typeOf(graph: Graph<Node>, identifier: Identifier) -> Term? {
+	return graph.nodes[identifier]?.type
+}
+
+
 private func simplify(type: Term) -> Term {
 	return Substitution(
 		(type.freeVariables

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -3,10 +3,9 @@
 public func constraints(graph: Graph<Node>) -> (Term, assumptions: AssumptionSet, constraints: ConstraintSet) {
 	let parameters = Node.parameters(graph)
 	let returns = Node.returns(graph)
-	if returns.count == 0 {
-		return (.Unit, [:], [])
-	}
-	return (Term(), [:], [])
+	return (reduce(parameters, Term.Unit) {
+		.function(Term(), $0.0)
+	}, [:], [])
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -1,12 +1,12 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public func constraints(graph: Graph<Node>) -> (Term, assumptions: AssumptionSet, constraints: ConstraintSet) {
+public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet) {
 	let parameters = Node.parameters(graph)
 	let returns = Node.returns(graph)
 	let returnType: Term = reduce(returns, nil) { $0.0.map { .product(Term(), $0) } ?? Term() } ?? .Unit
 	return (reduce(parameters, returnType) {
 		.function(Term(), $0.0)
-	}, [:], [])
+	}, [])
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -4,7 +4,7 @@ public func typeOf(graph: Graph<Node>) -> Either<Error<Identifier>, Term> {
 	let (type, constraints) = TesseractCore.constraints(graph)
 	return solve(constraints).either(
 		ifLeft: { Either.left(Error($0.description, Identifier())) },
-		ifRight: { Either.right($0.apply(type)) })
+		ifRight: { Either.right($0.apply(type).generalize()) })
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -1,0 +1,12 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+public func constraints(graph: Graph<Node>) -> (Term, assumptions: AssumptionSet, constraints: ConstraintSet) {
+	let returns = Node.returns(graph)
+	if returns.count == 0 {
+		return (.Unit, [:], [])
+	}
+	return (Term(), [:], [])
+}
+
+
+import Manifold

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -4,7 +4,7 @@ public func typeOf(graph: Graph<Node>) -> Either<Error<Identifier>, Term> {
 	let (type, constraints) = TesseractCore.constraints(graph)
 	return solve(constraints).either(
 		ifLeft: { Either.left(Error($0.description, Identifier())) },
-		ifRight: { Either.right($0.apply(type).generalize()) })
+		ifRight: { Either.right(normalize($0.apply(type)).generalize()) })
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -15,7 +15,11 @@ private func typeOf(graph: Graph<Node>, identifier: Identifier) -> Term? {
 }
 
 private func typeOf(graph: Graph<Node>, endpoint: (identifier: Identifier, inputIndex: Int)) -> Term? {
-	return graph.nodes[endpoint.identifier]?.symbol.type.parameters[endpoint.inputIndex]
+	return graph.nodes[endpoint.identifier].map {
+		$0.`return` != nil ?
+			$0.type
+		:	$0.type.parameters[endpoint.inputIndex]
+	}
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -7,7 +7,7 @@ public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet
 	let constraints = ConstraintSet(lazy(graph.edges).flatMap { [ typeOf(graph, $0.source.identifier)!.`return` === typeOf(graph, $0.destination)! ] })
 
 	let returnType: Term = first(returns).map { reduce(dropFirst(returns), $0, flip(Term.product)) } ?? .Unit
-	return (reduce(parameters, returnType, flip(Term.function)).generalize(), constraints)
+	return (reduce(parameters, returnType, flip(Term.function)), constraints)
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -1,8 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet) {
-	let types = graph.map { $0.symbol.type }
-
 	let returns = Node.returns(graph).map { typeOf(graph, $0.0)! }
 	let parameters = Node.parameters(graph).map { typeOf(graph, $0.0)! }
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -5,8 +5,11 @@ public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet
 
 	let returns = Node.returns(graph).map { typeOf(graph, $0.0)! }
 	let parameters = Node.parameters(graph).map { typeOf(graph, $0.0)! }
+
+	let constraints = ConstraintSet(lazy(graph.edges).flatMap { [ typeOf(graph, $0.source.identifier)!.`return` === typeOf(graph, $0.destination)! ] })
+
 	let returnType: Term? = reduce(returns, nil) { previous, each in previous.map { Term.product(each, $0) } ?? each }
-	return (simplify(reduce(parameters, returnType ?? .Unit, flip(Term.function))), [])
+	return (simplify(reduce(parameters, returnType ?? .Unit, flip(Term.function))), constraints)
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -6,8 +6,8 @@ public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet
 
 	let constraints = ConstraintSet(lazy(graph.edges).flatMap { [ typeOf(graph, $0.source.identifier)!.`return` === typeOf(graph, $0.destination)! ] })
 
-	let returnType: Term? = reduce(returns, nil) { previous, each in previous.map { Term.product(each, $0) } ?? each }
-	return (simplify(reduce(parameters, returnType ?? .Unit, flip(Term.function))), constraints)
+	let returnType: Term = first(returns).map { reduce(dropFirst(returns), $0, flip(Term.product)) } ?? .Unit
+	return (reduce(parameters, returnType, flip(Term.function)).generalize(), constraints)
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -3,7 +3,8 @@
 public func constraints(graph: Graph<Node>) -> (Term, assumptions: AssumptionSet, constraints: ConstraintSet) {
 	let parameters = Node.parameters(graph)
 	let returns = Node.returns(graph)
-	return (reduce(parameters, returns.count > 0 ? Term() : Term.Unit) {
+	let returnType: Term = reduce(returns, nil) { $0.0.map { .product(Term(), $0) } ?? Term() } ?? .Unit
+	return (reduce(parameters, returnType) {
 		.function(Term(), $0.0)
 	}, [:], [])
 }

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -11,7 +11,15 @@ public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet
 
 
 private func simplify(type: Term) -> Term {
-	return Substitution(lazy(enumerate(type.freeVariables |> (flip(sorted) <| { $0.value < $1.value }))).map { ($1, Term(integerLiteral: $0)) }).apply(type)
+	return Substitution(
+		(type.freeVariables
+			|>	(flip(sorted) <| { $0.value < $1.value })
+			|>	reverse
+			|>	enumerate
+			|>	lazy)
+			.map {
+				($1, Term(integerLiteral: $0))
+			}).apply(type)
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -19,7 +19,9 @@ private func simplify(type: Term) -> Term {
 			|>	lazy)
 			.map {
 				($1, Term(integerLiteral: $0))
-			}).apply(type)
+			})
+		.apply(type)
+		.generalize()
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -1,8 +1,8 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet) {
-	let returns = Node.returns(graph).map { typeOf(graph, $0.0)! }
-	let parameters = Node.parameters(graph).map { typeOf(graph, $0.0)! }
+	let parameters = Node.parameters(graph).map { typeOf(graph, $0.0)! }.reverse()
+	let returns = Node.returns(graph).map { typeOf(graph, $0.0)! }.reverse()
 
 	let constraints = ConstraintSet(lazy(graph.edges).flatMap { [ typeOf(graph, $0.source.identifier)!.`return` === typeOf(graph, $0.destination)! ] })
 

--- a/TesseractCore/Node.swift
+++ b/TesseractCore/Node.swift
@@ -16,6 +16,11 @@ public enum Node: Equatable, Printable {
 		return Array(graph.nodes.filter { $1.`return` != nil })
 	}
 
+	/// All parameters in a given `graph`.
+	public static func parameters(graph: Graph<Node>) -> [(Identifier, Node)] {
+		return Array(graph.nodes.filter { $1.parameter != nil })
+	}
+
 
 	/// Case analysis.
 	public func analysis<Result>(@noescape #ifParameter: (Int, Term) -> Result, @noescape ifReturn: (Int, Term) -> Result, @noescape ifSymbolic: Symbol -> Result) -> Result {

--- a/TesseractCore/Node.swift
+++ b/TesseractCore/Node.swift
@@ -2,10 +2,10 @@
 
 public enum Node: Equatable, Printable {
 	/// A parameter of a graph.
-	case Parameter(Int, Term?)
+	case Parameter(Int, Term)
 
 	/// A return of a graph.
-	case Return(Int, Term?)
+	case Return(Int, Term)
 
 	/// An arbitrary graph node referencing a value bound in the environment.
 	case Symbolic(Symbol)
@@ -23,7 +23,7 @@ public enum Node: Equatable, Printable {
 
 
 	/// Case analysis.
-	public func analysis<Result>(@noescape #ifParameter: (Int, Term?) -> Result, @noescape ifReturn: (Int, Term?) -> Result, @noescape ifSymbolic: Symbol -> Result) -> Result {
+	public func analysis<Result>(@noescape #ifParameter: (Int, Term) -> Result, @noescape ifReturn: (Int, Term) -> Result, @noescape ifSymbolic: Symbol -> Result) -> Result {
 		switch self {
 		case let Parameter(index, type):
 			return ifParameter(index, type)
@@ -37,8 +37,8 @@ public enum Node: Equatable, Printable {
 
 	public var type: Term {
 		return analysis(
-			ifParameter: { $1 ?? Term() },
-			ifReturn: { $1 ?? Term() },
+			ifParameter: { $1 },
+			ifReturn: { $1 },
 			ifSymbolic: { $0.type })
 	}
 
@@ -49,14 +49,14 @@ public enum Node: Equatable, Printable {
 			ifSymbolic: id)
 	}
 
-	public var parameter: (Int, Term?)? {
+	public var parameter: (Int, Term)? {
 		return analysis(
 			ifParameter: unit,
 			ifReturn: const(nil),
 			ifSymbolic: const(nil))
 	}
 
-	public var `return`: (Int, Term?)? {
+	public var `return`: (Int, Term)? {
 		return analysis(
 			ifParameter: const(nil),
 			ifReturn: unit,

--- a/TesseractCore/Node.swift
+++ b/TesseractCore/Node.swift
@@ -13,7 +13,7 @@ public enum Node: Equatable, Printable {
 
 	/// All returns in a given `graph`.
 	public static func returns(graph: Graph<Node>) -> [(Identifier, Node)] {
-		return []
+		return Array(graph.nodes.filter { $1.`return` != nil })
 	}
 
 

--- a/TesseractCore/Node.swift
+++ b/TesseractCore/Node.swift
@@ -63,6 +63,11 @@ public enum Node: Equatable, Printable {
 			ifSymbolic: const(nil))
 	}
 
+	/// The index of parameter/return nodes, nil for symbolic nodes.
+	public var index: Int? {
+		return parameter?.0 ?? `return`?.0
+	}
+
 
 	// MARK: Printable
 

--- a/TesseractCore/Node.swift
+++ b/TesseractCore/Node.swift
@@ -35,6 +35,13 @@ public enum Node: Equatable, Printable {
 	}
 
 
+	public var type: Term {
+		return analysis(
+			ifParameter: { $1 ?? Term() },
+			ifReturn: { $1 ?? Term() },
+			ifSymbolic: { $0.type })
+	}
+
 	public var symbol: Symbol {
 		return analysis(
 			ifParameter: Symbol.index,

--- a/TesseractCore/Node.swift
+++ b/TesseractCore/Node.swift
@@ -27,8 +27,8 @@ public enum Node: Equatable, Printable {
 		switch self {
 		case let Parameter(index, type):
 			return ifParameter(index, type)
-		case let Return(symbol):
-			return ifReturn(symbol)
+		case let Return(index, type):
+			return ifReturn(index, type)
 		case let Symbolic(symbol):
 			return ifSymbolic(symbol)
 		}

--- a/TesseractCore/Node.swift
+++ b/TesseractCore/Node.swift
@@ -11,6 +11,12 @@ public enum Node: Equatable, Printable {
 	case Symbolic(Symbol)
 
 
+	/// All returns in a given `graph`.
+	public static func returns(graph: Graph<Node>) -> [(Identifier, Node)] {
+		return []
+	}
+
+
 	/// Case analysis.
 	public func analysis<Result>(@noescape #ifParameter: (Int, Term) -> Result, @noescape ifReturn: (Int, Term) -> Result, @noescape ifSymbolic: Symbol -> Result) -> Result {
 		switch self {

--- a/TesseractCore/Node.swift
+++ b/TesseractCore/Node.swift
@@ -13,12 +13,18 @@ public enum Node: Equatable, Printable {
 
 	/// All returns in a given `graph`.
 	public static func returns(graph: Graph<Node>) -> [(Identifier, Node)] {
-		return Array(graph.nodes.filter { $1.`return` != nil })
+		return Array(
+			(lazy(graph.nodes)
+				.filter { $1.`return` != nil })
+				|>	(flip(sorted) <| { $0.1.index! < $1.1.index! }))
 	}
 
 	/// All parameters in a given `graph`.
 	public static func parameters(graph: Graph<Node>) -> [(Identifier, Node)] {
-		return Array(graph.nodes.filter { $1.parameter != nil })
+		return Array(
+			(lazy(graph.nodes)
+				.filter { $1.parameter != nil })
+				|>	(flip(sorted) <| { $0.1.index! < $1.1.index! }))
 	}
 
 

--- a/TesseractCore/Node.swift
+++ b/TesseractCore/Node.swift
@@ -2,10 +2,10 @@
 
 public enum Node: Equatable, Printable {
 	/// A parameter of a graph.
-	case Parameter(Symbol.IndexType)
+	case Parameter(Int, Term?)
 
 	/// A return of a graph.
-	case Return(Symbol.IndexType)
+	case Return(Int, Term?)
 
 	/// An arbitrary graph node referencing a value bound in the environment.
 	case Symbolic(Symbol)
@@ -23,7 +23,7 @@ public enum Node: Equatable, Printable {
 
 
 	/// Case analysis.
-	public func analysis<Result>(@noescape #ifParameter: (Int, Term) -> Result, @noescape ifReturn: (Int, Term) -> Result, @noescape ifSymbolic: Symbol -> Result) -> Result {
+	public func analysis<Result>(@noescape #ifParameter: (Int, Term?) -> Result, @noescape ifReturn: (Int, Term?) -> Result, @noescape ifSymbolic: Symbol -> Result) -> Result {
 		switch self {
 		case let Parameter(index, type):
 			return ifParameter(index, type)
@@ -44,19 +44,19 @@ public enum Node: Equatable, Printable {
 
 	public var symbol: Symbol {
 		return analysis(
-			ifParameter: Symbol.index,
-			ifReturn: Symbol.index,
+			ifParameter: { Symbol.index($0.0, type) },
+			ifReturn: { Symbol.index($0.0, type) },
 			ifSymbolic: id)
 	}
 
-	public var parameter: Symbol.IndexType? {
+	public var parameter: (Int, Term?)? {
 		return analysis(
 			ifParameter: unit,
 			ifReturn: const(nil),
 			ifSymbolic: const(nil))
 	}
 
-	public var `return`: Symbol.IndexType? {
+	public var `return`: (Int, Term?)? {
 		return analysis(
 			ifParameter: const(nil),
 			ifReturn: unit,

--- a/TesseractCore/Symbol.swift
+++ b/TesseractCore/Symbol.swift
@@ -13,8 +13,6 @@ public enum Symbol: Hashable, Printable {
 	case Named(String, Term)
 	case Index(Int, Term)
 
-	public typealias IndexType = (Int, Term)
-
 
 	public var name: String {
 		switch self {

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -38,7 +38,7 @@ final class EvaluationTests: XCTestCase {
 
 	func testGraphNodeWithNoBoundInputsEvaluatesToGraph() {
 		let (a, b) = (Identifier(), Identifier())
-		let constant = Graph<Node>(nodes: [ a: node("true"), b: .Return(0, nil) ], edges: [ Edge((a, 0), (b, 0)) ])
+		let constant = Graph<Node>(nodes: [ a: node("true"), b: .Return(0, 0) ], edges: [ Edge((a, 0), (b, 0)) ])
 
 		let truthy = Symbol.Named("truthy", .Bool)
 		let (c, graph) = createGraph(truthy)
@@ -49,7 +49,7 @@ final class EvaluationTests: XCTestCase {
 
 	func testGraphNodeWithBoundInputsAppliesInput() {
 		let (a, b) = (Identifier(), Identifier())
-		let identity = Graph<Node>(nodes: [ a: .Parameter(0, nil), b: .Return(0, nil) ], edges: [ Edge((a, 0), (b, 0)) ])
+		let identity = Graph<Node>(nodes: [ a: .Parameter(0, 0), b: .Return(0, 0) ], edges: [ Edge((a, 0), (b, 0)) ])
 
 		let identitySymbol = Symbol.Named("identity", .forall([ 0 ], .function(0, 0)))
 		let (c, d) = (Identifier(), Identifier())

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -38,7 +38,7 @@ final class EvaluationTests: XCTestCase {
 
 	func testGraphNodeWithNoBoundInputsEvaluatesToGraph() {
 		let (a, b) = (Identifier(), Identifier())
-		let constant = Graph<Node>(nodes: [ a: node("true"), b: .Return((0, .Bool)) ], edges: [ Edge((a, 0), (b, 0)) ])
+		let constant = Graph<Node>(nodes: [ a: node("true"), b: .Return(0, nil) ], edges: [ Edge((a, 0), (b, 0)) ])
 
 		let truthy = Symbol.Named("truthy", .Bool)
 		let (c, graph) = createGraph(truthy)
@@ -49,7 +49,7 @@ final class EvaluationTests: XCTestCase {
 
 	func testGraphNodeWithBoundInputsAppliesInput() {
 		let (a, b) = (Identifier(), Identifier())
-		let identity = Graph<Node>(nodes: [ a: .Parameter((0, 0)), b: .Return((0, 0)) ], edges: [ Edge((a, 0), (b, 0)) ])
+		let identity = Graph<Node>(nodes: [ a: .Parameter(0, nil), b: .Return(0, nil) ], edges: [ Edge((a, 0), (b, 0)) ])
 
 		let identitySymbol = Symbol.Named("identity", .forall([ 0 ], .function(0, 0)))
 		let (c, d) = (Identifier(), Identifier())

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -16,6 +16,10 @@ final class InferenceTests: XCTestCase {
 	func testGraphsWithOneParameterAndOneReturnHaveFunctionTypeFromVariableToDifferentVariable() {
 		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))])), ==, .function(1, 0))
 	}
+
+	func testGraphsWithMultipleParametersHaveCurriedFunctionType() {
+		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((0, .Unit))])), ==, .function(1, .function(0, .Unit)))
+	}
 }
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -31,6 +31,8 @@ final class InferenceTests: XCTestCase {
 }
 
 
+// MARK: Helpers
+
 private func type(graph: Graph<Node>) -> Term {
 	return simplify(constraints(graph).0)
 }

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -42,6 +42,14 @@ private func simplify(type: Term) -> Term {
 }
 
 
+// MARK: Fixtures
+
+private let identity: Graph<Node> = {
+	let (a, b) = (Identifier(), Identifier())
+	return Graph(nodes: [ a: .Parameter((0, .Unit)), b: .Return((0, .Unit)) ], edges: [ Edge((a, 0), (b, 0)) ])
+}()
+
+
 import Assertions
 import Manifold
 import Prelude

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -5,6 +5,10 @@ final class InferenceTests: XCTestCase {
 		assert(type(Graph()), ==, .Unit)
 	}
 
+	func testGraphsWithOneReturnHaveVariableType() {
+		assert(type(Graph(nodes: [Identifier(): .Return((0, .Unit))])), ==, 0)
+	}
+
 	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {
 		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit))], edges: [])), ==, .function(0, .Unit))
 	}

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -5,7 +5,7 @@ final class InferenceTests: XCTestCase {
 		assert(constraints(Graph()).0, ==, .Unit)
 	}
 
-	func testGraphsWithOneParameterAndNoReturnsHaveFunctionType() {
+	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {
 		let generated = constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit))], edges: []))
 		assert(simplify(generated.0), == ,.function(0, .Unit))
 	}

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -4,6 +4,11 @@ final class InferenceTests: XCTestCase {
 	func testGraphsWithoutReturnsHaveUnitType() {
 		assert(constraints(Graph()).0, ==, .Unit)
 	}
+
+	func testGraphsWithOneParameterAndNoReturnsHaveFunctionType() {
+		let generated = constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit))], edges: []))
+		assert(simplify(generated.0), == ,.function(0, .Unit))
+	}
 }
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -7,7 +7,7 @@ final class InferenceTests: XCTestCase {
 		assert(constraints(Graph()).0, ==, .Unit)
 	}
 
-	func testGraphsWithOneReturnHaveVariableType() {
+	func testGraphsWithOneReturnArePolymorphic() {
 		assert(constraints(Graph(nodes: [Identifier(): .Return((0, .Unit))])).0, ==, .forall([ 0 ], 0))
 	}
 
@@ -15,7 +15,7 @@ final class InferenceTests: XCTestCase {
 		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit))])).0, ==, Term.function(0, .Unit).generalize())
 	}
 
-	func testGraphsWithOneParameterAndOneReturnHaveFunctionTypeFromVariableToDifferentVariable() {
+	func testGraphsWithOneParameterAndOneReturnHavePolymorphicFunctionType() {
 		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))])).0, ==, Term.function(0, 1).generalize())
 	}
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -8,27 +8,27 @@ final class InferenceTests: XCTestCase {
 	}
 
 	func testGraphsWithOneReturnArePolymorphic() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return((0, .Unit))])).0, ==, .forall([ 0 ], 0))
+		assert(constraints(Graph(nodes: [Identifier(): .Return(0, nil)])).0, ==, .forall([ 0 ], 0))
 	}
 
 	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit))])).0, ==, Term.function(0, .Unit).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, nil)])).0, ==, Term.function(0, .Unit).generalize())
 	}
 
 	func testGraphsWithOneParameterAndOneReturnHavePolymorphicFunctionType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))])).0, ==, Term.function(0, 1).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, nil), Identifier(): .Return(0, nil)])).0, ==, Term.function(0, 1).generalize())
 	}
 
 	func testGraphsWithMultipleParametersHaveCurriedFunctionType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit))])).0, ==, Term.function(0, .function(1, .Unit)).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, nil), Identifier(): .Parameter(1, nil)])).0, ==, Term.function(0, .function(1, .Unit)).generalize())
 	}
 
 	func testGraphsWithMultipleReturnsHaveProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, Term.product(0, 1).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Return(0, nil), Identifier(): .Return(1, nil)])).0, ==, Term.product(0, 1).generalize())
 	}
 
 	func testGraphsWithMultipleParametersAndMultipleReturnsHaveCurriedFunctionTypeProducingProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit)), Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, Term.function(0, .function(1, .product(2, 3))).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, nil), Identifier(): .Parameter(1, nil), Identifier(): .Return(0, nil), Identifier(): .Return(1, nil)])).0, ==, Term.function(0, .function(1, .product(2, 3))).generalize())
 	}
 }
 
@@ -37,7 +37,7 @@ final class InferenceTests: XCTestCase {
 
 private let identity: Graph<Node> = {
 	let (a, b) = (Identifier(), Identifier())
-	return Graph(nodes: [ a: .Parameter((0, .Unit)), b: .Return((0, .Unit)) ], edges: [ Edge((a, 0), (b, 0)) ])
+	return Graph(nodes: [ a: .Parameter(0, nil), b: .Return(0, nil) ], edges: [ Edge((a, 0), (b, 0)) ])
 }()
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -8,27 +8,27 @@ final class InferenceTests: XCTestCase {
 	}
 
 	func testGraphsWithOneReturnHaveVariableType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return((0, .Unit))])).0, ==, 0)
+		assert(constraints(Graph(nodes: [Identifier(): .Return((0, .Unit))])).0, ==, .forall([ 0 ], 0))
 	}
 
 	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit))])).0, ==, .function(0, .Unit))
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit))])).0, ==, Term.function(0, .Unit).generalize())
 	}
 
 	func testGraphsWithOneParameterAndOneReturnHaveFunctionTypeFromVariableToDifferentVariable() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))])).0, ==, .function(0, 1))
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))])).0, ==, Term.function(0, 1).generalize())
 	}
 
 	func testGraphsWithMultipleParametersHaveCurriedFunctionType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit))])).0, ==, .function(0, .function(1, .Unit)))
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit))])).0, ==, Term.function(0, .function(1, .Unit)).generalize())
 	}
 
 	func testGraphsWithMultipleReturnsHaveProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, .product(0, 1))
+		assert(constraints(Graph(nodes: [Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, Term.product(0, 1).generalize())
 	}
 
 	func testGraphsWithMultipleParametersAndMultipleReturnsHaveCurriedFunctionTypeProducingProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit)), Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, .function(0, .function(1, .product(2, 3))))
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit)), Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, Term.function(0, .function(1, .product(2, 3))).generalize())
 	}
 }
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -8,6 +8,10 @@ final class InferenceTests: XCTestCase {
 	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {
 		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit))], edges: [])), ==, .function(0, .Unit))
 	}
+
+	func testGraphsWithOneParameterAndOneReturnHaveFunctionTypeFromVariableToDifferentVariable() {
+		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))], edges: [])), ==, .function(1, 0))
+	}
 }
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -41,6 +41,14 @@ final class InferenceTests: XCTestCase {
 	func testIdentityGraphHasConstraintsRelatingItsTypeVariables() {
 		assert(constraints(identity).1, ==, [ 0 === 1 ])
 	}
+
+
+	// MARK: Types
+
+	func testIdentityIsGeneralized() {
+		assert(typeOf(identity).left, ==, nil)
+		assert(typeOf(identity).right, ==, Term.function(0, 0).generalize())
+	}
 }
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -13,11 +13,12 @@ final class InferenceTests: XCTestCase {
 
 
 private func simplify(type: Term) -> Term {
-	return Substitution(lazy(enumerate(type.freeVariables)).map { ($1, Term(integerLiteral: $0)) }).apply(type)
+	return Substitution(lazy(enumerate(type.freeVariables |> (flip(sorted) <| { $0.value < $1.value }))).map { ($1, Term(integerLiteral: $0)) }).apply(type)
 }
 
 
 import Assertions
 import Manifold
+import Prelude
 import TesseractCore
 import XCTest

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -8,31 +8,31 @@ final class InferenceTests: XCTestCase {
 	}
 
 	func testGraphsWithOneReturnArePolymorphic() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0)])).0, ==, .forall([ 0 ], 0))
+		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0)])).0, ==, 0)
 	}
 
 	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0)])).0, ==, Term.function(0, .Unit).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0)])).0, ==, Term.function(0, .Unit))
 	}
 
 	func testGraphsWithOneParameterAndOneReturnHavePolymorphicFunctionType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Return(0, 1)])).0, ==, Term.function(0, 1).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Return(0, 1)])).0, ==, Term.function(0, 1))
 	}
 
 	func testGraphsWithMultipleParametersHaveCurriedFunctionType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Parameter(1, 1)])).0, ==, Term.function(0, .function(1, .Unit)).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Parameter(1, 1)])).0, ==, Term.function(0, .function(1, .Unit)))
 	}
 
 	func testGraphsWithMultipleReturnsHaveProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0), Identifier(): .Return(1, 1)])).0, ==, Term.product(0, 1).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0), Identifier(): .Return(1, 1)])).0, ==, Term.product(0, 1))
 	}
 
 	func testGraphsWithSeveralReturnsEtc() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0), Identifier(): .Return(1, 1), Identifier(): .Return(2, 2)])).0, ==, Term.product(0, .product(1, 2)).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0), Identifier(): .Return(1, 1), Identifier(): .Return(2, 2)])).0, ==, Term.product(0, .product(1, 2)))
 	}
 
 	func testGraphsWithMultipleParametersAndMultipleReturnsHaveCurriedFunctionTypeProducingProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Parameter(1, 1), Identifier(): .Return(0, 2), Identifier(): .Return(1, 3)])).0, ==, Term.function(0, .function(1, .product(2, 3))).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Parameter(1, 1), Identifier(): .Return(0, 2), Identifier(): .Return(1, 3)])).0, ==, Term.function(0, .function(1, .product(2, 3))))
 	}
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -1,6 +1,8 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 final class InferenceTests: XCTestCase {
+	// MARK: Types
+
 	func testGraphsWithoutReturnsHaveUnitType() {
 		assert(constraints(Graph()).0, ==, .Unit)
 	}

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -6,8 +6,7 @@ final class InferenceTests: XCTestCase {
 	}
 
 	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {
-		let generated = constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit))], edges: []))
-		assert(simplify(generated.0), == ,.function(0, .Unit))
+		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit))], edges: [])), ==, .function(0, .Unit))
 	}
 }
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -8,27 +8,27 @@ final class InferenceTests: XCTestCase {
 	}
 
 	func testGraphsWithOneReturnArePolymorphic() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return(0, nil)])).0, ==, .forall([ 0 ], 0))
+		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0)])).0, ==, .forall([ 0 ], 0))
 	}
 
 	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, nil)])).0, ==, Term.function(0, .Unit).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0)])).0, ==, Term.function(0, .Unit).generalize())
 	}
 
 	func testGraphsWithOneParameterAndOneReturnHavePolymorphicFunctionType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, nil), Identifier(): .Return(0, nil)])).0, ==, Term.function(0, 1).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Return(0, 1)])).0, ==, Term.function(0, 1).generalize())
 	}
 
 	func testGraphsWithMultipleParametersHaveCurriedFunctionType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, nil), Identifier(): .Parameter(1, nil)])).0, ==, Term.function(0, .function(1, .Unit)).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Parameter(1, 1)])).0, ==, Term.function(0, .function(1, .Unit)).generalize())
 	}
 
 	func testGraphsWithMultipleReturnsHaveProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return(0, nil), Identifier(): .Return(1, nil)])).0, ==, Term.product(0, 1).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0), Identifier(): .Return(1, 1)])).0, ==, Term.product(0, 1).generalize())
 	}
 
 	func testGraphsWithMultipleParametersAndMultipleReturnsHaveCurriedFunctionTypeProducingProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, nil), Identifier(): .Parameter(1, nil), Identifier(): .Return(0, nil), Identifier(): .Return(1, nil)])).0, ==, Term.function(0, .function(1, .product(2, 3))).generalize())
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Parameter(1, 1), Identifier(): .Return(0, 2), Identifier(): .Return(1, 3)])).0, ==, Term.function(0, .function(1, .product(2, 3))).generalize())
 	}
 }
 
@@ -37,7 +37,7 @@ final class InferenceTests: XCTestCase {
 
 private let identity: Graph<Node> = {
 	let (a, b) = (Identifier(), Identifier())
-	return Graph(nodes: [ a: .Parameter(0, nil), b: .Return(0, nil) ], edges: [ Edge((a, 0), (b, 0)) ])
+	return Graph(nodes: [ a: .Parameter(0, 0), b: .Return(0, 1) ], edges: [ Edge((a, 0), (b, 0)) ])
 }()
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -24,6 +24,10 @@ final class InferenceTests: XCTestCase {
 	func testGraphsWithMultipleReturnsHaveProductType() {
 		assert(type(Graph(nodes: [Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])), ==, .product(1, 0))
 	}
+
+	func testGraphsWithMultipleParametersAndMultipleReturnsHaveCurriedFunctionTypeProducingProductType() {
+		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit)), Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])), ==, .function(3, .function(2, .product(1, 0))))
+	}
 }
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -2,43 +2,32 @@
 
 final class InferenceTests: XCTestCase {
 	func testGraphsWithoutReturnsHaveUnitType() {
-		assert(type(Graph()), ==, .Unit)
+		assert(constraints(Graph()).0, ==, .Unit)
 	}
 
 	func testGraphsWithOneReturnHaveVariableType() {
-		assert(type(Graph(nodes: [Identifier(): .Return((0, .Unit))])), ==, 0)
+		assert(constraints(Graph(nodes: [Identifier(): .Return((0, .Unit))])).0, ==, 0)
 	}
 
 	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {
-		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit))])), ==, .function(0, .Unit))
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit))])).0, ==, .function(0, .Unit))
 	}
 
 	func testGraphsWithOneParameterAndOneReturnHaveFunctionTypeFromVariableToDifferentVariable() {
-		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))])), ==, .function(1, 0))
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))])).0, ==, .function(1, 0))
 	}
 
 	func testGraphsWithMultipleParametersHaveCurriedFunctionType() {
-		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit))])), ==, .function(1, .function(0, .Unit)))
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit))])).0, ==, .function(1, .function(0, .Unit)))
 	}
 
 	func testGraphsWithMultipleReturnsHaveProductType() {
-		assert(type(Graph(nodes: [Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])), ==, .product(1, 0))
+		assert(constraints(Graph(nodes: [Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, .product(1, 0))
 	}
 
 	func testGraphsWithMultipleParametersAndMultipleReturnsHaveCurriedFunctionTypeProducingProductType() {
-		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit)), Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])), ==, .function(3, .function(2, .product(1, 0))))
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit)), Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, .function(3, .function(2, .product(1, 0))))
 	}
-}
-
-
-// MARK: Helpers
-
-private func type(graph: Graph<Node>) -> Term {
-	return simplify(constraints(graph).0)
-}
-
-private func simplify(type: Term) -> Term {
-	return Substitution(lazy(enumerate(type.freeVariables |> (flip(sorted) <| { $0.value < $1.value }))).map { ($1, Term(integerLiteral: $0)) }).apply(type)
 }
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -20,6 +20,10 @@ final class InferenceTests: XCTestCase {
 	func testGraphsWithMultipleParametersHaveCurriedFunctionType() {
 		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit))])), ==, .function(1, .function(0, .Unit)))
 	}
+
+	func testGraphsWithMultipleReturnsHaveProductType() {
+		assert(type(Graph(nodes: [Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])), ==, .product(1, 0))
+	}
 }
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -18,7 +18,7 @@ final class InferenceTests: XCTestCase {
 	}
 
 	func testGraphsWithMultipleParametersHaveCurriedFunctionType() {
-		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((0, .Unit))])), ==, .function(1, .function(0, .Unit)))
+		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit))])), ==, .function(1, .function(0, .Unit)))
 	}
 }
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -34,6 +34,13 @@ final class InferenceTests: XCTestCase {
 	func testGraphsWithMultipleParametersAndMultipleReturnsHaveCurriedFunctionTypeProducingProductType() {
 		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Parameter(1, 1), Identifier(): .Return(0, 2), Identifier(): .Return(1, 3)])).0, ==, Term.function(0, .function(1, .product(2, 3))).generalize())
 	}
+
+
+	// MARK: Constraints
+
+	func testIdentityGraphHasConstraintsRelatingItsTypeVariables() {
+		assert(constraints(identity).1, ==, [ 0 === 1 ])
+	}
 }
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -27,6 +27,10 @@ final class InferenceTests: XCTestCase {
 		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0), Identifier(): .Return(1, 1)])).0, ==, Term.product(0, 1).generalize())
 	}
 
+	func testGraphsWithSeveralReturnsEtc() {
+		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0), Identifier(): .Return(1, 1), Identifier(): .Return(2, 2)])).0, ==, Term.product(0, .product(1, 2)).generalize())
+	}
+
 	func testGraphsWithMultipleParametersAndMultipleReturnsHaveCurriedFunctionTypeProducingProductType() {
 		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Parameter(1, 1), Identifier(): .Return(0, 2), Identifier(): .Return(1, 3)])).0, ==, Term.function(0, .function(1, .product(2, 3))).generalize())
 	}

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -14,19 +14,19 @@ final class InferenceTests: XCTestCase {
 	}
 
 	func testGraphsWithOneParameterAndOneReturnHaveFunctionTypeFromVariableToDifferentVariable() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))])).0, ==, .function(1, 0))
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))])).0, ==, .function(0, 1))
 	}
 
 	func testGraphsWithMultipleParametersHaveCurriedFunctionType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit))])).0, ==, .function(1, .function(0, .Unit)))
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit))])).0, ==, .function(0, .function(1, .Unit)))
 	}
 
 	func testGraphsWithMultipleReturnsHaveProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, .product(1, 0))
+		assert(constraints(Graph(nodes: [Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, .product(0, 1))
 	}
 
 	func testGraphsWithMultipleParametersAndMultipleReturnsHaveCurriedFunctionTypeProducingProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit)), Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, .function(3, .function(2, .product(1, 0))))
+		assert(constraints(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Parameter((1, .Unit)), Identifier(): .Return((0, .Unit)), Identifier(): .Return((1, .Unit))])).0, ==, .function(0, .function(1, .product(2, 3))))
 	}
 }
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -2,7 +2,7 @@
 
 final class InferenceTests: XCTestCase {
 	func testGraphsWithoutReturnsHaveUnitType() {
-		assert(constraints(Graph()).0, ==, .Unit)
+		assert(type(Graph()), ==, .Unit)
 	}
 
 	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -12,6 +12,10 @@ final class InferenceTests: XCTestCase {
 }
 
 
+private func type(graph: Graph<Node>) -> Term {
+	return simplify(constraints(graph).0)
+}
+
 private func simplify(type: Term) -> Term {
 	return Substitution(lazy(enumerate(type.freeVariables |> (flip(sorted) <| { $0.value < $1.value }))).map { ($1, Term(integerLiteral: $0)) }).apply(type)
 }

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -10,11 +10,11 @@ final class InferenceTests: XCTestCase {
 	}
 
 	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {
-		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit))], edges: [])), ==, .function(0, .Unit))
+		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit))])), ==, .function(0, .Unit))
 	}
 
 	func testGraphsWithOneParameterAndOneReturnHaveFunctionTypeFromVariableToDifferentVariable() {
-		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))], edges: [])), ==, .function(1, 0))
+		assert(type(Graph(nodes: [Identifier(): .Parameter((0, .Unit)), Identifier(): .Return((0, .Unit))])), ==, .function(1, 0))
 	}
 }
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -7,6 +7,11 @@ final class InferenceTests: XCTestCase {
 }
 
 
+private func simplify(type: Term) -> Term {
+	return Substitution(lazy(enumerate(type.freeVariables)).map { ($1, Term(integerLiteral: $0)) }).apply(type)
+}
+
+
 import Assertions
 import Manifold
 import TesseractCore

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -1,0 +1,13 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+final class InferenceTests: XCTestCase {
+	func testGraphsWithoutReturnsHaveUnitType() {
+		assert(constraints(Graph()).0, ==, .Unit)
+	}
+}
+
+
+import Assertions
+import Manifold
+import TesseractCore
+import XCTest

--- a/TesseractCoreTests/NodeTests.swift
+++ b/TesseractCoreTests/NodeTests.swift
@@ -4,6 +4,12 @@ final class NodeTests: XCTestCase {
 	func testEmptyGraphsHaveNoReturns() {
 		assert(Node.returns(Graph()), ==, [])
 	}
+
+	func testFindsReturnsInWellFormedGraphs() {
+		let node = Node.Return((0, .Unit))
+		let graph = Graph(nodes: [Identifier(): node], edges: [])
+		assert(Node.returns(graph).first?.1, ==, node)
+	}
 }
 
 

--- a/TesseractCoreTests/NodeTests.swift
+++ b/TesseractCoreTests/NodeTests.swift
@@ -10,6 +10,16 @@ final class NodeTests: XCTestCase {
 		let graph = Graph(nodes: [Identifier(): node], edges: [])
 		assert(Node.returns(graph).first?.1, ==, node)
 	}
+
+	func testEmptyGraphsHaveNoParameters() {
+		assert(Node.parameters(Graph()), ==, [])
+	}
+
+	func testFindsParametersInWellFormedGraphs() {
+		let node = Node.Parameter((0, .Unit))
+		let graph = Graph(nodes: [Identifier(): node], edges: [])
+		assert(Node.parameters(graph).first?.1, ==, node)
+	}
 }
 
 

--- a/TesseractCoreTests/NodeTests.swift
+++ b/TesseractCoreTests/NodeTests.swift
@@ -1,0 +1,12 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+final class NodeTests: XCTestCase {
+	func testEmptyGraphsHaveNoReturns() {
+		assert(Node.returns(Graph()), ==, [])
+	}
+}
+
+
+import Assertions
+import TesseractCore
+import XCTest

--- a/TesseractCoreTests/NodeTests.swift
+++ b/TesseractCoreTests/NodeTests.swift
@@ -6,7 +6,7 @@ final class NodeTests: XCTestCase {
 	}
 
 	func testFindsReturnsInWellFormedGraphs() {
-		let node = Node.Return(0, nil)
+		let node = Node.Return(0, 0)
 		let graph = Graph(nodes: [Identifier(): node], edges: [])
 		assert(Node.returns(graph).first?.1, ==, node)
 	}
@@ -16,7 +16,7 @@ final class NodeTests: XCTestCase {
 	}
 
 	func testFindsParametersInWellFormedGraphs() {
-		let node = Node.Parameter(0, nil)
+		let node = Node.Parameter(0, 0)
 		let graph = Graph(nodes: [Identifier(): node], edges: [])
 		assert(Node.parameters(graph).first?.1, ==, node)
 	}

--- a/TesseractCoreTests/NodeTests.swift
+++ b/TesseractCoreTests/NodeTests.swift
@@ -6,7 +6,7 @@ final class NodeTests: XCTestCase {
 	}
 
 	func testFindsReturnsInWellFormedGraphs() {
-		let node = Node.Return((0, .Unit))
+		let node = Node.Return(0, nil)
 		let graph = Graph(nodes: [Identifier(): node], edges: [])
 		assert(Node.returns(graph).first?.1, ==, node)
 	}
@@ -16,7 +16,7 @@ final class NodeTests: XCTestCase {
 	}
 
 	func testFindsParametersInWellFormedGraphs() {
-		let node = Node.Parameter((0, .Unit))
+		let node = Node.Parameter(0, nil)
 		let graph = Graph(nodes: [Identifier(): node], edges: [])
 		assert(Node.parameters(graph).first?.1, ==, node)
 	}


### PR DESCRIPTION
- [x] Construct types for graphs based on parameters/returns.
- [x] Generate constraints based on edges (applications).
- [x] Solve constraints.
- [x] Simplify the representation of the type.

Fixes #4.