### PR TITLE
Produce types at every node

### DIFF
--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public func typeOf(graph: Graph<Node>) -> Either<Error<Identifier>, Term> {
-	let (type, constraints) = TesseractCore.constraints(graph)
+	let (type, constraints, _) = TesseractCore.constraints(graph)
 	return solve(constraints)
 		.either(
 		ifLeft: { Either.left(Error($0.description, Identifier())) },
@@ -13,7 +13,7 @@ public func typeOf(graph: Graph<Node>) -> Either<Error<Identifier>, Term> {
 }
 
 
-public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet) {
+public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet, graph: Graph<Term>) {
 	var cursor = 0
 	let instantiated = graph.map { $0.type.instantiate { Variable(integerLiteral: --cursor) } }
 
@@ -27,7 +27,7 @@ public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet
 	})
 
 	let returnType: Term = first(returns).map { reduce(dropFirst(returns), $0, flip(Term.product)) } ?? .Unit
-	return (reduce(parameters, returnType, flip(Term.function)), constraints)
+	return (reduce(parameters, returnType, flip(Term.function)), constraints, instantiated)
 }
 
 

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -2,9 +2,14 @@
 
 public func typeOf(graph: Graph<Node>) -> Either<Error<Identifier>, Term> {
 	let (type, constraints) = TesseractCore.constraints(graph)
-	return solve(constraints).either(
+	return solve(constraints)
+		.either(
 		ifLeft: { Either.left(Error($0.description, Identifier())) },
-		ifRight: { Either.right(normalize($0.apply(type)).generalize()) })
+		ifRight: {
+			let t = $0.apply(type)
+			let n = normalization(t)
+			return Either.right(n.apply(t).generalize())
+		})
 }
 
 
@@ -27,7 +32,7 @@ public func constraints(graph: Graph<Node>) -> (Term, constraints: ConstraintSet
 
 
 /// Substitute the variables in a type such that it is represented densely with variables in-order starting at 0.
-private func normalize(type: Term) -> Term {
+private func normalization(type: Term) -> Substitution {
 	/// Produce the free variables of `type` in depth first order.
 	func freeVariables(type: Type<(Set<Variable>, [Variable])>) -> (Set<Variable>, [Variable]) {
 		let binary: ((Set<Variable>, [Variable]), (Set<Variable>, [Variable])) -> (Set<Variable>, [Variable]) = { t1, t2 in
@@ -51,7 +56,6 @@ private func normalize(type: Term) -> Term {
 			.map {
 				($1, Term(integerLiteral: $0))
 			})
-			.apply(type)
 }
 
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -73,9 +73,8 @@ final class InferenceTests: XCTestCase {
 	}
 
 	func testInstantiatesNodeTypes() {
-		let result = typeOf(constantByWrappingNode)
-		assert(result.left, ==, nil)
-		assert(result.right, ==, Term.function(0, .function(1, 0)).generalize())
+		assert(typeOf(constantByWrappingNode).left, ==, nil)
+		assert(typeOf(constantByWrappingNode).right, ==, Term.function(0, .function(1, 0)).generalize())
 	}
 }
 


### PR DESCRIPTION
`typeOf()` produces the graph of instantiated types at every node. This allows for some interesting introspection.