### PR TITLE
Identifier locality

### DIFF
--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -7,6 +7,10 @@ public struct Graph<T>: CollectionType, Printable {
 		sanitize(self.edges)
 	}
 
+	public init<S: SequenceType where S.Generator.Element == Dictionary<Identifier, T>.Generator.Element>(nodes: S) {
+		self.init(nodes: nodes, edges: [])
+	}
+
 	public init() {
 		self.init(nodes: [:], edges: [])
 	}

--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -1,14 +1,14 @@
 //  Copyright (c) 2014 Rob Rix. All rights reserved.
 
 public struct Graph<T>: CollectionType, Printable {
-	public init<S: SequenceType where S.Generator.Element == (Identifier, T)>(nodes: S, edges: Set<Edge> = []) {
+	public init<S1: SequenceType, S2: SequenceType where S1.Generator.Element == (Identifier, T), S2.Generator.Element == Edge>(nodes: S1, edges: S2) {
 		self.nodes = Dictionary(nodes)
-		self.edges = edges
-		sanitize(edges)
+		self.edges = Set(edges)
+		sanitize(self.edges)
 	}
 
 	public init() {
-		self.init(nodes: [])
+		self.init(nodes: [:], edges: [])
 	}
 
 

--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -1,8 +1,8 @@
 //  Copyright (c) 2014 Rob Rix. All rights reserved.
 
 public struct Graph<T>: CollectionType, Printable {
-	public init(nodes: [Identifier: T] = [:], edges: Set<Edge> = []) {
-		self.nodes = nodes
+	public init<S: SequenceType where S.Generator.Element == (Identifier, T)>(nodes: S, edges: Set<Edge> = []) {
+		self.nodes = Dictionary(nodes)
 		self.edges = edges
 		sanitize(edges)
 	}

--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -11,6 +11,10 @@ public struct Graph<T>: CollectionType, Printable {
 		self.init(nodes: nodes, edges: [])
 	}
 
+	public init<S2: SequenceType where S2.Generator.Element == Edge>(nodes: [T], edges: S2) {
+		self.init(nodes: lazy(enumerate(nodes)).map { (Identifier($0), $1) }, edges: edges)
+	}
+
 	public init() {
 		self.init(nodes: [:], edges: [])
 	}

--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -7,6 +7,10 @@ public struct Graph<T>: CollectionType, Printable {
 		sanitize(edges)
 	}
 
+	public init() {
+		self.init(nodes: [])
+	}
+
 
 	// MARK: Primitive methods
 

--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -15,6 +15,10 @@ public struct Graph<T>: CollectionType, Printable {
 		self.init(nodes: lazy(enumerate(nodes)).map { (Identifier($0), $1) }, edges: edges)
 	}
 
+	public init(nodes: [T]) {
+		self.init(nodes: lazy(enumerate(nodes)).map { (Identifier($0), $1) }, edges: [])
+	}
+
 	public init() {
 		self.init(nodes: [:], edges: [])
 	}

--- a/TesseractCore/Identifier.swift
+++ b/TesseractCore/Identifier.swift
@@ -2,11 +2,11 @@
 
 public struct Identifier: Comparable, Hashable, Printable {
 	public init(graph: Graph<Node>) {
-		value = graph.nodes.isEmpty ? 0 : maxElement(graph.nodes.keys).value + 1
+		self.init(graph.nodes.isEmpty ? 0 : maxElement(graph.nodes.keys).value + 1)
 	}
 
 	public init() {
-		self.value = Identifier.cursor++
+		self.init(Identifier.cursor++)
 	}
 
 

--- a/TesseractCore/Identifier.swift
+++ b/TesseractCore/Identifier.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2014 Rob Rix. All rights reserved.
 
-public struct Identifier: Comparable, Hashable, Printable {
+public struct Identifier: Comparable, Hashable, IntegerLiteralConvertible, Printable {
 	public init(_ graph: Graph<Node>) {
 		self.init(graph.nodes.isEmpty ? 0 : maxElement(graph.nodes.keys).value + 1)
 	}
@@ -25,6 +25,13 @@ public struct Identifier: Comparable, Hashable, Printable {
 
 	public var hashValue: Int {
 		return value.hashValue
+	}
+
+
+	// MARK: IntegerLiteralConvertible
+
+	public init(integerLiteral: Int) {
+		self.init(integerLiteral)
 	}
 
 

--- a/TesseractCore/Identifier.swift
+++ b/TesseractCore/Identifier.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2014 Rob Rix. All rights reserved.
 
 public struct Identifier: Comparable, Hashable, Printable {
-	public init(graph: Graph<Node>) {
+	public init(_ graph: Graph<Node>) {
 		self.init(graph.nodes.isEmpty ? 0 : maxElement(graph.nodes.keys).value + 1)
 	}
 

--- a/TesseractCore/Identifier.swift
+++ b/TesseractCore/Identifier.swift
@@ -1,6 +1,10 @@
 //  Copyright (c) 2014 Rob Rix. All rights reserved.
 
 public struct Identifier: Comparable, Hashable, Printable {
+	public init(graph: Graph<Node>) {
+		value = graph.nodes.isEmpty ? 0 : maxElement(graph.nodes.keys).value + 1
+	}
+
 	public init() {
 		self.value = Identifier.cursor++
 	}

--- a/TesseractCore/Identifier.swift
+++ b/TesseractCore/Identifier.swift
@@ -5,10 +5,6 @@ public struct Identifier: Comparable, Hashable, IntegerLiteralConvertible, Print
 		self.init(graph.nodes.isEmpty ? 0 : maxElement(graph.nodes.keys).value + 1)
 	}
 
-	public init() {
-		self.init(Identifier.cursor++)
-	}
-
 	public init(_ value: Int) {
 		self.value = value
 	}

--- a/TesseractCore/Identifier.swift
+++ b/TesseractCore/Identifier.swift
@@ -9,6 +9,10 @@ public struct Identifier: Comparable, Hashable, IntegerLiteralConvertible, Print
 		self.init(Identifier.cursor++)
 	}
 
+	public init(_ value: Int) {
+		self.value = value
+	}
+
 
 	// MARK: Endpoint constructors
 
@@ -43,10 +47,6 @@ public struct Identifier: Comparable, Hashable, IntegerLiteralConvertible, Print
 
 
 	// MARK: Private
-
-	private init(_ value: Int) {
-		self.value = value
-	}
 
 	private let value: Int
 

--- a/TesseractCore/Identifier.swift
+++ b/TesseractCore/Identifier.swift
@@ -45,8 +45,6 @@ public struct Identifier: Comparable, Hashable, IntegerLiteralConvertible, Print
 	// MARK: Private
 
 	private let value: Int
-
-	private static var cursor = 0
 }
 
 public func == (left: Identifier, right: Identifier) -> Bool {

--- a/TesseractCore/Identifier.swift
+++ b/TesseractCore/Identifier.swift
@@ -10,6 +10,9 @@ public struct Identifier: Comparable, Hashable, IntegerLiteralConvertible, Print
 	}
 
 
+	public let value: Int
+
+
 	// MARK: Endpoint constructors
 
 	public func input(index: Int) -> Edge.Destination {
@@ -40,11 +43,6 @@ public struct Identifier: Comparable, Hashable, IntegerLiteralConvertible, Print
 	public var description: String {
 		return value.description
 	}
-
-
-	// MARK: Private
-
-	private let value: Int
 }
 
 public func == (left: Identifier, right: Identifier) -> Bool {

--- a/TesseractCore/Identifier.swift
+++ b/TesseractCore/Identifier.swift
@@ -37,6 +37,10 @@ public struct Identifier: Comparable, Hashable, Printable {
 
 	// MARK: Private
 
+	private init(_ value: Int) {
+		self.value = value
+	}
+
 	private let value: Int
 
 	private static var cursor = 0

--- a/TesseractCore/Importing.swift
+++ b/TesseractCore/Importing.swift
@@ -35,7 +35,7 @@ private let attributeList: Parser<String, [String: String]>.Function = attribute
 private let attributes: Parser<String, [String: String]>.Function = (ignore("[") ++ attributeList ++ ignore("]")) | { _, index in ([:], index) }
 
 private let graph: Parser<String, Graph<String>>.Function = edge+ --> { _, _, edgeParses in
-	let nodeData = map(Set(lazy(edgeParses).flatMap { source, destination in [source.0, destination.0] })) { (Identifier(), $0) }
+	let nodeData = map(enumerate(Set(lazy(edgeParses).flatMap { source, destination in [source.0, destination.0] }))) { (Identifier($0), $1) }
 	let nodeIdentifiers = Dictionary(nodeData.map(swap))
 	let nodes = Dictionary(nodeData)
 	let edges: Set<Edge> = reduce(lazy(edgeParses).map { source, destination in

--- a/TesseractCore/Inference.swift
+++ b/TesseractCore/Inference.swift
@@ -4,7 +4,7 @@ public func typeOf(graph: Graph<Node>) -> Either<Error<Identifier>, Term> {
 	let (type, constraints, _) = TesseractCore.constraints(graph)
 	return solve(constraints)
 		.either(
-		ifLeft: { Either.left(Error($0.description, Identifier())) },
+		ifLeft: { Either.left(Error($0.description, Identifier(graph))) },
 		ifRight: {
 			let t = $0.apply(type)
 			let n = normalization(t)
@@ -17,7 +17,7 @@ public func typeOf(graph: Graph<Node>) -> (Either<Error<Identifier>, Term>, Grap
 	return solve(constraints)
 		.map { normalization(type).compose($0) }
 		.either(
-			ifLeft: { (Either.left(Error($0.description, Identifier())), types) },
+			ifLeft: { (Either.left(Error($0.description, Identifier(graph))), types) },
 			ifRight: { s in
 				let t = s.apply(type)
 				let n = normalization(t)

--- a/TesseractCoreTests/EvaluationTests.swift
+++ b/TesseractCoreTests/EvaluationTests.swift
@@ -2,8 +2,7 @@
 
 final class EvaluationTests: XCTestCase {
 	func createGraph(symbol: Symbol) -> (Identifier, Graph<Node>) {
-		let a = Identifier()
-		return (a, Graph(nodes: [ a: .Symbolic(symbol) ]))
+		return (Identifier(0), Graph(nodes: [ .Symbolic(symbol) ]))
 	}
 
 	func node(symbolName: String) -> Node {
@@ -29,16 +28,14 @@ final class EvaluationTests: XCTestCase {
 	}
 
 	func testFunctionNodeWithBoundInputAppliesInput() {
-		let (a, b) = (Identifier(), Identifier())
-		let graph = Graph(nodes: [ a: node("true"), b: node("identity") ], edges: [ Edge((a, 0), (b, 0)) ])
-		let evaluated = evaluate(graph, b, Prelude)
+		let graph = Graph(nodes: [ node("true"), node("identity") ], edges: [ Edge((0, 0), (1, 0)) ])
+		let evaluated = evaluate(graph, 1, Prelude)
 
 		assertEqual(assertNotNil(evaluated.right?.value.constant()), true)
 	}
 
 	func testGraphNodeWithNoBoundInputsEvaluatesToGraph() {
-		let (a, b) = (Identifier(), Identifier())
-		let constant = Graph<Node>(nodes: [ a: node("true"), b: .Return(0, 0) ], edges: [ Edge((a, 0), (b, 0)) ])
+		let constant = Graph<Node>(nodes: [ node("true"), .Return(0, 0) ], edges: [ Edge((0, 0), (1, 0)) ])
 
 		let truthy = Symbol.Named("truthy", .Bool)
 		let (c, graph) = createGraph(truthy)
@@ -48,13 +45,11 @@ final class EvaluationTests: XCTestCase {
 	}
 
 	func testGraphNodeWithBoundInputsAppliesInput() {
-		let (a, b) = (Identifier(), Identifier())
-		let identity = Graph<Node>(nodes: [ a: .Parameter(0, 0), b: .Return(0, 0) ], edges: [ Edge((a, 0), (b, 0)) ])
+		let identity = Graph<Node>(nodes: [ .Parameter(0, 0), .Return(0, 0) ], edges: [ Edge((0, 0), (1, 0)) ])
 
 		let identitySymbol = Symbol.Named("identity", .forall([ 0 ], .function(0, 0)))
-		let (c, d) = (Identifier(), Identifier())
-		let graph = Graph(nodes: [ c: node("true"), d: .Symbolic(identitySymbol) ], edges: [ Edge((c, 0), (d, 0)) ])
-		let evaluated = evaluate(graph, d, Prelude + (identitySymbol, Value(identity)))
+		let graph = Graph(nodes: [ node("true"), .Symbolic(identitySymbol) ], edges: [ Edge((0, 0), (1, 0)) ])
+		let evaluated = evaluate(graph, 1, Prelude + (identitySymbol, Value(identity)))
 		assert(evaluated.right?.value.constant(), ==, true)
 	}
 }

--- a/TesseractCoreTests/ExportingTests.swift
+++ b/TesseractCoreTests/ExportingTests.swift
@@ -2,8 +2,7 @@
 
 final class ExportingTests: XCTestCase {
 	func testExporting() {
-		let (a, b) = (Identifier(), Identifier())
-		let graph = Graph(nodes: [ a: "item1", b: "item2" ], edges: [ Edge((a, 0), (b, 0)) ])
+		let graph = Graph(nodes: [ "item1", "item2" ], edges: [ Edge((0, 0), (1, 0)) ])
 		XCTAssertEqual(exportDOT("test", graph), "digraph test {\n\t\"item1\" -> \"item2\" [sametail=0,headlabel=0];\n}")
 	}
 }

--- a/TesseractCoreTests/Fixtures.swift
+++ b/TesseractCoreTests/Fixtures.swift
@@ -1,26 +1,20 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-private let x = Identifier()
-private let result = Identifier()
-private let zero = Identifier()
-private let lessThan = Identifier()
-private let iff = Identifier()
-private let unaryMinus = Identifier()
 let absoluteValue = Graph<String>(nodes: [
-	x: "x",
-	result: "result",
-	zero: "0",
-	unaryMinus: "unaryMinus",
-	iff: "if",
-	lessThan: "lessThan"
+	"x",
+	"result",
+	"0",
+	"unaryMinus",
+	"if",
+	"lessThan"
 ], edges: [
-	Edge(x, lessThan.input(0)),
-	Edge(zero, lessThan.input(1)),
-	Edge(lessThan, iff.input(0)),
-	Edge(x, unaryMinus.input(0)),
-	Edge(unaryMinus, iff.input(1)),
-	Edge(x, iff.input(2)),
-	Edge(iff, result.input(0))
+	Edge(0, Identifier(5).input(0)),
+	Edge(2, Identifier(5).input(1)),
+	Edge(5, Identifier(4).input(0)),
+	Edge(0, Identifier(3).input(0)),
+	Edge(3, Identifier(5).input(1)),
+	Edge(0, Identifier(4).input(2)),
+	Edge(4, Identifier(1).input(0))
 ])
 
 

--- a/TesseractCoreTests/GraphTests.swift
+++ b/TesseractCoreTests/GraphTests.swift
@@ -2,29 +2,27 @@
 
 final class GraphTests: XCTestCase {
 	func testIdentityGraph() {
-		let (a, b) = (Identifier(), Identifier())
-		let graph = Graph(nodes: [ a: (), b: () ], edges: [ Edge((a, 0), (b, 0)) ])
+		let graph = Graph(nodes: [ (), () ], edges: [ Edge((0, 0), (1, 0)) ])
 		XCTAssertEqual(graph.nodes.count, 2)
 		XCTAssertEqual(graph.edges.count, 1)
 	}
 
 	func testSanitizesEdgesOnNodesMutation() {
-		let (a, b) = (Identifier(), Identifier())
-		var graph = Graph(nodes: [ a: (), b: () ], edges: [ Edge((a, 0), (b, 0)) ])
+		var graph = Graph(nodes: [ (), () ], edges: [ Edge((0, 0), (1, 0)) ])
 		XCTAssertEqual(graph.edges.count, 1)
-		graph.nodes.removeValueForKey(a)
+		graph.nodes.removeValueForKey(0)
 		XCTAssertEqual(graph.edges.count, 0)
 	}
 
 	func testSanitizesEdgesOnEdgesMutation() {
 		var graph = Graph<()>()
 		XCTAssertEqual(graph.edges.count, 0)
-		graph.edges.insert(Edge((Identifier(), 0), (Identifier(), 0)))
+		graph.edges.insert(Edge((0, 0), (1, 0)))
 		XCTAssertEqual(graph.edges.count, 0)
 	}
 
 	func testAttachingDataToNodes() {
-		let graph: Graph<Int> = Graph(nodes: [ Identifier(): 0, Identifier(): 1 ])
+		let graph: Graph<Int> = Graph(nodes: [ 0, 1 ])
 	}
 
 	func testAbsoluteValueGraph() {
@@ -33,24 +31,21 @@ final class GraphTests: XCTestCase {
 	}
 
 	func testMappingAcrossGraph() {
-		let (a,b) = (Identifier(), Identifier())
-		let graph = Graph(nodes: [a: "1", b: "2"], edges: [Edge(a, b.input(0))])
+		let graph = Graph(nodes: [ "1", "2" ], edges: [Edge(0, Identifier(1).input(0))])
 		let newGraph = graph.map { $0.toInt() ?? 0 }
-		let expectedGraph = Graph(nodes: [a: 1, b: 2], edges: [Edge(a, b.input(0))])
+		let expectedGraph = Graph(nodes: [ 1, 2 ], edges: [Edge(0, Identifier(1).input(0))])
 		assert(newGraph, ==, expectedGraph)
 	}
 
 	func testReductionDoesNotTraverseWithoutEdges() {
-		let (a, b) = (Identifier(), Identifier())
-		let graph = Graph(nodes: [ a: "a", b: "b" ])
-		let result = graph.reduce(a, "_") { into, each in into + each.1 }
+		let graph = Graph(nodes: [ "a", "b" ])
+		let result = graph.reduce(0, "_") { into, each in into + each.1 }
 		XCTAssertEqual(result, "_a")
 	}
 
 	func testReductionTraversesEdges() {
-		let (a, b, c, result) = (Identifier(), Identifier(), Identifier(), Identifier())
-		let graph = Graph(nodes: [ a: "a", b: "b", c: "c", result: "!" ], edges: [ Edge(a, result.input(0)), Edge(b, result.input(0)), Edge(c, result.input(0)) ])
-		let reduced = graph.reduce(result, "_") { into, each in into + each.1 }
+		let graph = Graph(nodes: [ "a", "b", "c", "!" ], edges: [ Edge(0, Identifier(3).input(0)), Edge(1, Identifier(3).input(0)), Edge(2, Identifier(3).input(0)) ])
+		let reduced = graph.reduce(3, "_") { into, each in into + each.1 }
 		XCTAssertEqual(reduced, "_abc!")
 	}
 }

--- a/TesseractCoreTests/ImportingTests.swift
+++ b/TesseractCoreTests/ImportingTests.swift
@@ -19,8 +19,7 @@ final class ImportingTests: XCTestCase {
 		let rawGraph = "digraph test {\n\t\"1\" -> \"2\" [sametail=0,headlabel=0];\n}"
 		if let (_, parsedGraph) = importDOT(rawGraph) {
 			let graph = parsedGraph.map { $0.toInt() ?? 0 }
-			let (a, b) = (Identifier(), Identifier())
-			let expectedGraph = Graph(nodes: [a: 1, b: 2], edges: Set([Edge(a, b.input(0))]))
+			let expectedGraph = Graph(nodes: [1, 2], edges: Set([Edge(0, Identifier(1).input(0))]))
 			let parsedNodes = Set(graph.nodes.values.array)
 			let expectedNodes = Set(expectedGraph.nodes.values.array)
 

--- a/TesseractCoreTests/InferenceTests.swift
+++ b/TesseractCoreTests/InferenceTests.swift
@@ -8,31 +8,31 @@ final class InferenceTests: XCTestCase {
 	}
 
 	func testGraphsWithOneReturnArePolymorphic() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0)])).0, ==, 0)
+		assert(constraints(Graph(nodes: [.Return(0, 0)])).0, ==, 0)
 	}
 
 	func testGraphsWithOneParameterAndNoReturnsHaveFunctionTypeReturningUnit() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0)])).0, ==, Term.function(0, .Unit))
+		assert(constraints(Graph(nodes: [.Parameter(0, 0)])).0, ==, Term.function(0, .Unit))
 	}
 
 	func testGraphsWithOneParameterAndOneReturnHavePolymorphicFunctionType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Return(0, 1)])).0, ==, Term.function(0, 1))
+		assert(constraints(Graph(nodes: [.Parameter(0, 0), .Return(0, 1)])).0, ==, Term.function(0, 1))
 	}
 
 	func testGraphsWithMultipleParametersHaveCurriedFunctionType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Parameter(1, 1)])).0, ==, Term.function(0, .function(1, .Unit)))
+		assert(constraints(Graph(nodes: [.Parameter(0, 0), .Parameter(1, 1)])).0, ==, Term.function(0, .function(1, .Unit)))
 	}
 
 	func testGraphsWithMultipleReturnsHaveProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0), Identifier(): .Return(1, 1)])).0, ==, Term.product(0, 1))
+		assert(constraints(Graph(nodes: [.Return(0, 0), .Return(1, 1)])).0, ==, Term.product(0, 1))
 	}
 
 	func testGraphsWithSeveralReturnsEtc() {
-		assert(constraints(Graph(nodes: [Identifier(): .Return(0, 0), Identifier(): .Return(1, 1), Identifier(): .Return(2, 2)])).0, ==, Term.product(0, .product(1, 2)))
+		assert(constraints(Graph(nodes: [.Return(0, 0), .Return(1, 1), .Return(2, 2)])).0, ==, Term.product(0, .product(1, 2)))
 	}
 
 	func testGraphsWithMultipleParametersAndMultipleReturnsHaveCurriedFunctionTypeProducingProductType() {
-		assert(constraints(Graph(nodes: [Identifier(): .Parameter(0, 0), Identifier(): .Parameter(1, 1), Identifier(): .Return(0, 2), Identifier(): .Return(1, 3)])).0, ==, Term.function(0, .function(1, .product(2, 3))))
+		assert(constraints(Graph(nodes: [.Parameter(0, 0), .Parameter(1, 1), .Return(0, 2), .Return(1, 3)])).0, ==, Term.function(0, .function(1, .product(2, 3))))
 	}
 
 	func testIdentityGraphTypeInitiallyHasTwoTypeVariables() {
@@ -82,18 +82,18 @@ final class InferenceTests: XCTestCase {
 // MARK: Fixtures
 
 private let identity: Graph<Node> = {
-	let (a, b) = (Identifier(), Identifier())
+	let (a, b) = (Identifier(0), Identifier(1))
 	return Graph(nodes: [ a: .Parameter(0, 0), b: .Return(0, 1) ], edges: [ Edge((a, 0), (b, 0)) ])
 }()
 
 private let constant: Graph<Node> = {
-	let (a, b, c) = (Identifier(), Identifier(), Identifier())
+	let (a, b, c) = (Identifier(0), Identifier(1), Identifier(2))
 	return Graph(nodes: [ a: .Parameter(0, 0), b: .Parameter(1, 1), c: .Return(0, 2) ], edges: [ Edge((a, 0), (c, 0)) ])
 }()
 
 private let constantByWrappingNode: Graph<Node> = {
 	let constantType = Term.forall([0, 1], .function(0, .function(1, 0)))
-	let (a, b, c, d) = (Identifier(), Identifier(), Identifier(), Identifier())
+	let (a, b, c, d) = (Identifier(0), Identifier(1), Identifier(2), Identifier(3))
 	return Graph(nodes: [ a: .Parameter(0, 0), b: .Parameter(1, 1), c: .Return(0, 2), d: Node.Symbolic(Symbol.named("constant", constantType)) ], edges: [ Edge((a, 0), (d, 0)), Edge((b, 0), (d, 1)), Edge((d, 0), (c, 0)) ])
 }()
 

--- a/TesseractCoreTests/NodeTests.swift
+++ b/TesseractCoreTests/NodeTests.swift
@@ -7,7 +7,7 @@ final class NodeTests: XCTestCase {
 
 	func testFindsReturnsInWellFormedGraphs() {
 		let node = Node.Return(0, 0)
-		let graph = Graph(nodes: [Identifier(): node], edges: [])
+		let graph = Graph(nodes: [0: node], edges: [])
 		assert(Node.returns(graph).first?.1, ==, node)
 	}
 
@@ -17,7 +17,7 @@ final class NodeTests: XCTestCase {
 
 	func testFindsParametersInWellFormedGraphs() {
 		let node = Node.Parameter(0, 0)
-		let graph = Graph(nodes: [Identifier(): node], edges: [])
+		let graph = Graph(nodes: [0: node], edges: [])
 		assert(Node.parameters(graph).first?.1, ==, node)
 	}
 }

--- a/TesseractCoreTests/ValueTests.swift
+++ b/TesseractCoreTests/ValueTests.swift
@@ -25,13 +25,13 @@ final class ValueTests: XCTestCase {
 
 	func testApplicationOfConstantIsError() {
 		let value = Value(())
-		assertNotNil(value.apply(value, Identifier(), [:]).left)
+		assertNotNil(value.apply(value, 0, [:]).left)
 	}
 
 	func testApplicationOfIdentityIsArgument() {
 		let argument = Value(1)
 		let identity = Value(id as Any -> Any)
-		assertEqual(assertNotNil(identity.apply(argument, Identifier(), [:]).right)?.value.constant(), 1)
+		assertEqual(assertNotNil(identity.apply(argument, 0, [:]).right)?.value.constant(), 1)
 	}
 }
 


### PR DESCRIPTION
Identifiers are no longer implicitly stateful.

Construction is still convenient by means of new Graph & Identifier constructors—`Identifier(graph)` will pick a fresh identifier for the graph, and `Graph` can now be constructed with an array of identifiers.

Fixes #68.