### PR TITLE
Value destructor usability

### DIFF
--- a/TesseractCore/Value.swift
+++ b/TesseractCore/Value.swift
@@ -27,6 +27,12 @@ public enum Value: Printable {
 			ifGraph: const(nil))
 	}
 
+	public func constant<T>(_: T.Type) -> T? {
+		return analysis(
+			ifConstant: { $0 as? T },
+			ifGraph: const(nil))
+	}
+
 	public func function<T, U>() -> (T -> U)? {
 		return analysis(
 			ifConstant: { $0 as? T -> U },

--- a/TesseractCoreTests/ValueTests.swift
+++ b/TesseractCoreTests/ValueTests.swift
@@ -9,6 +9,14 @@ final class ValueTests: XCTestCase {
 		assertNil(Value(1).constant() as ()?)
 	}
 
+	func testConstantValueDestructuresToSomeOfSamePassedType() {
+		assert(Value(1).constant(Int.self), ==, 1)
+	}
+
+	func testConstantValueDestructuresToNoneOfDifferentPassedType() {
+		assertNil(Value(1).constant(Void.self))
+	}
+
 
 	func testFunctionValueDestructuresToSomeOfSameType() {
 		assertNotNil(Value(id as Any -> Any).function() as (Any -> Any)?)


### PR DESCRIPTION
Adds an override of `Value.constant` taking a metatype as its parameter.