### PR TITLE
Diff parameterized by equality

### DIFF
--- a/TesseractCore/DictionaryDifferentiator.swift
+++ b/TesseractCore/DictionaryDifferentiator.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public struct DictionaryDifferentiator<Key: Hashable, Value: Equatable> {
+public struct DictionaryDifferentiator<Key: Hashable, Value> {
 	public static func differentiate(#before: Dictionary<Key, Value>, after: Dictionary<Key, Value>, equals: (Value, Value) -> Bool) -> UnorderedDifferential<(Key, Value)> {
 		let (beforeKeys, afterKeys) = (Set(before.keys), Set(after.keys))
 		let changedKeys = Set(lazy(beforeKeys.intersect(afterKeys))

--- a/TesseractCore/DictionaryDifferentiator.swift
+++ b/TesseractCore/DictionaryDifferentiator.swift
@@ -1,11 +1,14 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public struct DictionaryDifferentiator<Key: Hashable, Value: Equatable> {
-	public static func differentiate(#before: Dictionary<Key, Value>, after: Dictionary<Key, Value>) -> UnorderedDifferential<(Key, Value)> {
+	public static func differentiate(#before: Dictionary<Key, Value>, after: Dictionary<Key, Value>, equals: (Value, Value) -> Bool) -> UnorderedDifferential<(Key, Value)> {
 		let (beforeKeys, afterKeys) = (Set(before.keys), Set(after.keys))
 		let changedKeys = Set(lazy(beforeKeys.intersect(afterKeys))
-			.filter { before[$0] != after[$0] })
+			.filter { !((before[$0] &&& after[$0]).map(equals) ?? (before[$0] == nil && after[$0] == nil)) })
 
 		return UnorderedDifferential(inserted: after[afterKeys.subtract(beforeKeys).union(changedKeys)], deleted: before[beforeKeys.subtract(afterKeys).union(changedKeys)])
 	}
 }
+
+
+import Prelude

--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -124,10 +124,7 @@ public struct Graph<C: CollectionType>: CollectionType, Printable {
 
 
 public func == <C: CollectionType where C.Generator.Element: Equatable> (left: Graph<C>, right: Graph<C>) -> Bool {
-	return
-		count(left.nodes) == count(right.nodes)
-	&&	reduce(lazy(zip(left.nodes, right.nodes)).map { $0 == $1 }, true, { $0 && $1 })
-	&&	left.edges == right.edges
+	return Graph.equals { $0 == $1 } (left, right)
 }
 
 

--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -65,6 +65,14 @@ public struct Graph<C: CollectionType>: CollectionType, Printable {
 	}
 
 
+	public static func equals(node: (C.Generator.Element, C.Generator.Element) -> Bool)(_ left: Graph<C>, _ right: Graph<C>) -> Bool {
+		if count(left.nodes) != count(right.nodes) { return false }
+		if left.edges != right.edges { return false }
+
+		return Swift.reduce(lazy(zip(left.nodes, right.nodes)).map(node), true) { $0 && $1 }
+	}
+
+
 	// MARK: CollectionType
 
 	public typealias Index = C.Index

--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2014 Rob Rix. All rights reserved.
 
 public struct Graph<C: CollectionType>: CollectionType, Printable {
-	public init<S: SequenceType where S.Generator.Element == Edge<C>>(nodes: C, edges: S) {
+	public init<S: SequenceType where S.Generator.Element == Edge>(nodes: C, edges: S) {
 		self.nodes = nodes
 		self.edges = Set(edges)
 		sanitize(self.edges)
@@ -21,7 +21,10 @@ public struct Graph<C: CollectionType>: CollectionType, Printable {
 		}
 	}
 
-	public var edges: Set<Edge<C>> {
+
+	public typealias Edge = TesseractCore.Edge<C>
+
+	public var edges: Set<Edge> {
 		didSet {
 			sanitize(edges.subtract(oldValue))
 		}
@@ -32,7 +35,7 @@ public struct Graph<C: CollectionType>: CollectionType, Printable {
 
 	public func map<U>(transform: Element -> U) -> Graph<[U]> {
 		return Graph<[U]>(nodes: Swift.map(nodes, transform), edges: Set(lazy(edges).map {
-			Edge<[U]>(Source(nodeIndex: Int(distance(self.nodes.startIndex, $0.source.nodeIndex).toIntMax()), outputIndex: $0.source.outputIndex), Destination(nodeIndex: Int(distance(self.nodes.startIndex, $0.destination.nodeIndex).toIntMax()), inputIndex: $0.destination.inputIndex))
+			TesseractCore.Edge<[U]>(Source(nodeIndex: Int(distance(self.nodes.startIndex, $0.source.nodeIndex).toIntMax()), outputIndex: $0.source.outputIndex), Destination(nodeIndex: Int(distance(self.nodes.startIndex, $0.destination.nodeIndex).toIntMax()), inputIndex: $0.destination.inputIndex))
 		}))
 	}
 
@@ -113,7 +116,7 @@ public struct Graph<C: CollectionType>: CollectionType, Printable {
 
 	// MARK: Private
 
-	private mutating func sanitize(added: Set<Edge<C>>) {
+	private mutating func sanitize(added: Set<Edge>) {
 		if added.count == 0 { return }
 		let extant = indices(nodes)
 		edges.subtractInPlace(lazy(added).filter { edge in

--- a/TesseractCore/Graph.swift
+++ b/TesseractCore/Graph.swift
@@ -11,6 +11,7 @@ public struct Graph<C: CollectionType>: CollectionType, Printable {
 		self.init(nodes: nodes, edges: [])
 	}
 
+
 	public var nodes: C {
 		willSet {
 			let removed = lazy(indices(nodes)).filter { !contains(indices(newValue), $0) }.array

--- a/TesseractCore/GraphDifferentiator.swift
+++ b/TesseractCore/GraphDifferentiator.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public struct GraphDifferentiator<C: CollectionType where C.Generator.Element: Equatable, C.Index: Hashable> {
+public struct GraphDifferentiator<C: CollectionType where C.Index: Hashable> {
 	public typealias Differential = (nodes: UnorderedDifferential<(C.Index, C.Generator.Element)>, edges: UnorderedDifferential<Edge<C>>)
 
 	public static func differentiate(#before: Graph<C>, after: Graph<C>, equals: (C.Generator.Element, C.Generator.Element) -> Bool) -> Differential {

--- a/TesseractCore/GraphDifferentiator.swift
+++ b/TesseractCore/GraphDifferentiator.swift
@@ -3,8 +3,8 @@
 public struct GraphDifferentiator<C: CollectionType where C.Generator.Element: Equatable, C.Index: Hashable> {
 	public typealias Differential = (nodes: UnorderedDifferential<(C.Index, C.Generator.Element)>, edges: UnorderedDifferential<Edge<C>>)
 
-	public static func differentiate(#before: Graph<C>, after: Graph<C>) -> Differential {
-		let nodes = DictionaryDifferentiator.differentiate(before: Dictionary(zip(indices(before.nodes), before.nodes)), after: Dictionary(zip(indices(after.nodes), after.nodes)))
+	public static func differentiate(#before: Graph<C>, after: Graph<C>, equals: (C.Generator.Element, C.Generator.Element) -> Bool) -> Differential {
+		let nodes = DictionaryDifferentiator.differentiate(before: Dictionary(zip(indices(before.nodes), before.nodes)), after: Dictionary(zip(indices(after.nodes), after.nodes)), equals: equals)
 		return Differential(nodes: nodes, edges: SetDifferentiator.differentiate(before: before.edges, after: after.edges))
 	}
 }


### PR DESCRIPTION
`Graph` & `Dictionary` differentials are computed parameterized by equality functions, and therefore can be performed over non-`Equatable` types (e.g. tuples).